### PR TITLE
Add default additives per bag

### DIFF
--- a/config.json
+++ b/config.json
@@ -50,7 +50,14 @@
         "1904": { "di": [0, 300], "so": [0, 1], "vi": [0, 10] }
       }
     },
-  
+
+    "additiveDefaultConfig": {
+      "SmofKabiven":            { "Vitalipid N Adult": 10, "Soluvit N": 1 },
+      "Kabiven":                { "Vitalipid N Adult": 10, "Soluvit N": 1 },
+      "SmofKabiven Peripheral": { "Vitalipid N Adult": 10, "Soluvit N": 1 },
+      "Kabiven Peripheral":     { "Vitalipid N Adult": 10, "Soluvit N": 1 }
+    },
+
     "dosageConfig": {
       "SmofKabiven":            { "min": 13, "max": 31, "maxDaily": 35 },
       "Kabiven":                { "min": 19, "max": 38, "maxDaily": 40 },

--- a/script.js
+++ b/script.js
@@ -20,6 +20,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const {
     bagConfig,
     additiveRangeConfig,
+    additiveDefaultConfig,
     dosageConfig,
     constants: {
       DIPEPTIVEN_PER_KG,
@@ -51,6 +52,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   const rangeAd  = $("rangeAdd2");
   const rangeVb1 = $("rangeAdd15");
   const rangeVc  = $("rangeAdd16");
+
+  const additiveInputs = {
+    "Soluvit N": $("add3"),
+    "Vitalipid N Adult": $("add4")
+  };
 
   /* ---------- 3. Inicjalizacja dat ---------- */
   const today = new Date().toISOString().slice(0, 10);
@@ -93,6 +99,15 @@ document.addEventListener("DOMContentLoaded", async () => {
     rangeVc.textContent  = VIT_C_RANGE;
   }
 
+  function applyDefaultAdditives () {
+    const defaults = additiveDefaultConfig[currentBag()];
+    if (!defaults) return;
+    for (const [name, val] of Object.entries(defaults)) {
+      const el = additiveInputs[name];
+      if (el) el.value = val;
+    }
+  }
+
   /* --- worki & kcal --- */
   function renderBagOptions () {
     const bag = currentBag();
@@ -110,6 +125,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     updateKcal();
     updateDosage();
     updateAdditiveRanges();
+    applyDefaultAdditives();
   }
 
   const updateKcal = () =>


### PR DESCRIPTION
## Summary
- allow default additive values for each bag type
- apply defaults for Vitalipid and Soluvit on bag selection

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68821e9bb69c832eb0863b0b12ddf320