### PR TITLE
Add manual override for additive defaults

### DIFF
--- a/config.json
+++ b/config.json
@@ -50,7 +50,38 @@
         "1904": { "di": [0, 300], "so": [0, 1], "vi": [0, 10] }
       }
     },
-  
+
+    "additiveDefaultConfig": {
+      "SmofKabiven": {
+        "Vitalipid N Adult": 10,
+        "Soluvit N": 1,
+        "Addamel N": 10,
+        "Vit. B1": 2,
+        "Vit. C": 5
+      },
+      "Kabiven": {
+        "Vitalipid N Adult": 10,
+        "Soluvit N": 1,
+        "Addamel N": 10,
+        "Vit. B1": 2,
+        "Vit. C": 5
+      },
+      "SmofKabiven Peripheral": {
+        "Vitalipid N Adult": 10,
+        "Soluvit N": 1,
+        "Addamel N": 10,
+        "Vit. B1": 2,
+        "Vit. C": 5
+      },
+      "Kabiven Peripheral": {
+        "Vitalipid N Adult": 10,
+        "Soluvit N": 1,
+        "Addamel N": 10,
+        "Vit. B1": 2,
+        "Vit. C": 5
+      }
+    },
+
     "dosageConfig": {
       "SmofKabiven":            { "min": 13, "max": 31, "maxDaily": 35 },
       "Kabiven":                { "min": 19, "max": 38, "maxDaily": 40 },

--- a/script.js
+++ b/script.js
@@ -20,6 +20,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const {
     bagConfig,
     additiveRangeConfig,
+    additiveDefaultConfig,
     dosageConfig,
     constants: {
       DIPEPTIVEN_PER_KG,
@@ -51,6 +52,22 @@ document.addEventListener("DOMContentLoaded", async () => {
   const rangeAd  = $("rangeAdd2");
   const rangeVb1 = $("rangeAdd15");
   const rangeVc  = $("rangeAdd16");
+
+  const additiveInputs = {
+    "Soluvit N": $("add3"),
+    "Vitalipid N Adult": $("add4"),
+    "Addamel N": $("add2"),
+    "Vit. B1": $("add15"),
+    "Vit. C": $("add16")
+  };
+
+  const manualAdditives = new Set();
+
+  for (const el of Object.values(additiveInputs)) {
+    if (el) {
+      el.addEventListener("input", () => manualAdditives.add(el.id));
+    }
+  }
 
   /* ---------- 3. Inicjalizacja dat ---------- */
   const today = new Date().toISOString().slice(0, 10);
@@ -93,6 +110,15 @@ document.addEventListener("DOMContentLoaded", async () => {
     rangeVc.textContent  = VIT_C_RANGE;
   }
 
+  function applyDefaultAdditives () {
+    const defaults = additiveDefaultConfig[currentBag()];
+    if (!defaults) return;
+    for (const [name, val] of Object.entries(defaults)) {
+      const el = additiveInputs[name];
+      if (el && !manualAdditives.has(el.id)) el.value = val;
+    }
+  }
+
   /* --- worki & kcal --- */
   function renderBagOptions () {
     const bag = currentBag();
@@ -110,6 +136,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     updateKcal();
     updateDosage();
     updateAdditiveRanges();
+    applyDefaultAdditives();
   }
 
   const updateKcal = () =>


### PR DESCRIPTION
## Summary
- detect manual edits in additive inputs
- skip applying default values if user already changed an additive

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68821e9bb69c832eb0863b0b12ddf320