### PR TITLE
Fix typo in magnesium additive label

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
 
         <tr><td class="label">Calcium chloratum 10 % amp. 10 ml</td><td class="input"><input type="text" id="add12" placeholder="ml"></td><td></td></tr>
         <tr><td class="label">Calcium glubionas 10 % amp. 10 ml</td><td class="input"><input type="text" id="add13" placeholder="ml"></td><td></td></tr>
-        <tr><td class="label">Magnesi sulf. 20 % amp. 10 ml</td><td class="input"><input type="text" id="add14" placeholder="ml"></td><td></td></tr>
+        <tr><td class="label">Magnesii sulf. 20 % amp. 10 ml</td><td class="input"><input type="text" id="add14" placeholder="ml"></td><td></td></tr>
 
         <!-- zmieniona etykieta NaCl -->
         <tr>


### PR DESCRIPTION
## Summary
- fix a typo in the label for the magnesium sulfate additive in `index.html`

## Testing
- `grep -n "Magnesii" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6882a06828c4832e860a4e1e3dd7f341