### PR TITLE
Add sodium field and adjust table width

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,11 @@
         </div>
 
         <div class="form-group">
+          <label for="sodium">Poziom sodu (mmol / L)</label>
+          <input type="text" id="sodium" value="140">
+        </div>
+
+        <div class="form-group">
           <label for="potassium">Poziom potasu (mmol / L)</label>
           <input type="text" id="potassium" value="3.5">
         </div>

--- a/style.css
+++ b/style.css
@@ -186,7 +186,8 @@ button:hover{background-color:#005fa3;}
 
 /* tabela parametrów mieszaniny */
 .mix-params-table{
-  width:100%;
+  width:auto;
+  max-width:25rem;
   border-collapse:collapse;
   margin-top:1rem;
 }


### PR DESCRIPTION
## Summary
- add sodium level input field above potassium in the form
- narrow the width of the mix parameters table

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883c88342fc832e9a6ceb192ca746cd