### PR TITLE
Zmiana etykiet dat i minimalnej szerokości panelu

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
 
         <div class="form-row">
           <div class="form-group">
-            <label for="dateFrom">Data od</label>
+          <label for="dateFrom">Data wystawienia</label>
             <input type="date" id="dateFrom">
           </div>
           <div class="form-group">
-            <label for="dateTo">Data do</label>
+          <label for="dateTo">Data podania</label>
             <input type="date" id="dateTo">
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -151,8 +151,8 @@ button:hover{background-color:#005fa3;}
 }
 .wrapper > .container.extras{
   flex:3 1 0;
-  max-width: none;
-  min-width: 800px;
+  max-width:none;
+  min-width:600px;
 }
 
 /* ---------- DODANE z <STYLE> (przeniesione) ---------- */


### PR DESCRIPTION
## Summary
- keep right panel flexible but set `min-width:600px`
- update date labels to "Data wystawienia" and "Data podania"

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883caa1ff28832e92087d36f13a9825