### PR TITLE
Align bag and nutrition selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,19 +76,19 @@
         <!-- wybrany worek + dawkowanie + kcal -->
         <tr>
           <td class="label">
-            <div class="form-group">
-              <label for="productType">Worek</label>
-              <select id="productType">
-                <option value="SmofKabiven">SmofKabiven</option>
-                <option value="Kabiven">Kabiven</option>
-              </select>
-            </div>
-            <div class="form-group">
-              <label for="nutritionType">Rodzaj żywienia</label>
-              <select id="nutritionType">
-                <option value="obwodowe" selected>Obwodowe</option>
-                <option value="centralne">Centralne</option>
-              </select>
+            <div class="form-row bag-select-row">
+              <div class="form-group">
+                <select id="productType">
+                  <option value="SmofKabiven">SmofKabiven</option>
+                  <option value="Kabiven">Kabiven</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <select id="nutritionType">
+                  <option value="obwodowe" selected>Obwodowe</option>
+                  <option value="centralne">Centralne</option>
+                </select>
+              </div>
             </div>
           </td>
           <td class="input"><select id="bagVolume"></select></td>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
 
         <!-- wybrany worek + dawkowanie + kcal -->
         <tr>
-          <td class="label">
+          <td class="label" colspan="3">
             <div class="form-row bag-select-row">
               <div class="form-group">
                 <select id="productType">
@@ -89,12 +89,14 @@
                   <option value="centralne">Centralne</option>
                 </select>
               </div>
+              <div class="form-group">
+                <select id="bagVolume"></select>
+              </div>
             </div>
-          </td>
-          <td class="input"><select id="bagVolume"></select></td>
-          <td class="dosing">
-            <em>Zalecane: </em><strong><span id="reqMin">0</span>–<span id="reqMax">0</span> ml/dobę</strong><br>
-            <em>Maksymalnie: </em><strong><span id="reqAbsMax">0</span> ml/dobę</strong>
+            <div class="dosing">
+              <em>Zalecane: </em><strong><span id="reqMin">0</span>–<span id="reqMax">0</span> ml/dobę</strong>
+              &nbsp;<em>Maksymalnie: </em><strong><span id="reqAbsMax">0</span> ml/dobę</strong>
+            </div>
           </td>
         </tr>
 

--- a/style.css
+++ b/style.css
@@ -173,10 +173,14 @@ button:hover{background-color:#005fa3;}
 
 /* blok dawkowania przy worku */
 .dosing{
-  display:inline-block;
-  margin-left:8px;
+  margin-top:0.5rem;
   font-size:0.9em;
-  vertical-align:middle;
+}
+
+/* wyróżniony wybór worka */
+#productType{
+  font-size:1.2rem;
+  font-weight:bold;
 }
 
 /* zakresy dodatków */

--- a/style.css
+++ b/style.css
@@ -206,3 +206,13 @@ button:hover{background-color:#005fa3;}
 .mix-params-table td:nth-child(3){
   text-align:right;
 }
+
+/* work type and nutrition selects side by side */
+.bag-select-row{
+  display:flex;
+  gap:1rem;
+}
+.bag-select-row .form-group{
+  flex:1;
+  margin-bottom:0;
+}


### PR DESCRIPTION
## Summary
- remove labels for bag and feeding type
- place product and nutrition dropdowns next to each other with flex styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883d0b10f00832eafec69996d21a19c