### PR TITLE
Add Na/K daily requirement & align units

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,19 +45,22 @@
         </div>
 
         <div class="form-group inline">
-          <label for="weight">Masa ciała (kg)</label>
+          <label for="weight">Masa ciała</label>
           <input type="text" id="weight" value="70">
+          <span class="unit">kg</span>
         </div>
 
 
         <div class="form-group inline">
-          <label for="sodium">Sód (mmol / L)</label>
+          <label for="sodium">Sód</label>
           <input type="text" id="sodium" value="140">
+          <span class="unit">mmol/L</span>
         </div>
 
         <div class="form-group inline">
-          <label for="potassium">Potas (mmol / L)</label>
+          <label for="potassium">Potas</label>
           <input type="text" id="potassium" value="3.5">
+          <span class="unit">mmol/L</span>
         </div>
 
       </form>
@@ -200,7 +203,7 @@
             <th>Parametr</th>
             <th>W mieszaninie</th>
             <th>Maks. w worku</th>
-            <th>Zapotrzebowanie</th>
+            <th>Zapotrzebowanie dobowe</th>
           </tr>
         </thead>
         <tbody>
@@ -208,19 +211,19 @@
             <td>Kalorie</td>
             <td><span id="bagCalories"></span> kcal</td>
             <td>&ndash;</td>
-            <td><span id="calReqMin">0</span> - <span id="calReqMax">0</span> kcal/dobę</td>
+            <td><span id="calReqMin">0</span> - <span id="calReqMax">0</span> kcal</td>
           </tr>
           <tr>
             <td>Sód</td>
             <td><span id="naTotal">0</span> mmol</td>
             <td><span id="naMax">0</span> mmol</td>
-            <td></td>
+            <td><span id="naReqMin">0</span> - <span id="naReqMax">0</span> mmol</td>
           </tr>
           <tr>
             <td>Potas</td>
             <td><span id="kTotal">0</span> mmol</td>
             <td><span id="kMax">0</span> mmol</td>
-            <td></td>
+            <td><span id="kReqMin">0</span> - <span id="kReqMax">0</span> mmol</td>
           </tr>
         </tbody>
       </table>

--- a/script.js
+++ b/script.js
@@ -60,6 +60,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   const naMaxSpan = $("naMax");
   const kTotal = $("kTotal");
   const kMaxSpan = $("kMax");
+  const naReqMin = $("naReqMin");
+  const naReqMax = $("naReqMax");
+  const kReqMin  = $("kReqMin");
+  const kReqMax  = $("kReqMax");
 
   const additiveInputs = {
     "Soluvit N": $("add3"),
@@ -179,8 +183,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (w) {
       calReqMin.textContent = Math.round(25 * w);
       calReqMax.textContent = Math.round(35 * w);
+      naReqMin.textContent = Math.round(0.5 * w);
+      naReqMax.textContent = Math.round(2 * w);
+      kReqMin.textContent  = Math.round(0.5 * w);
+      kReqMax.textContent  = Math.round(2 * w);
     } else {
       calReqMin.textContent = calReqMax.textContent = "0";
+      naReqMin.textContent = naReqMax.textContent = "0";
+      kReqMin.textContent  = kReqMax.textContent  = "0";
     }
 
     if (cfgDose && w) {

--- a/style.css
+++ b/style.css
@@ -85,6 +85,10 @@ body{
   width:5rem;
   flex:0 0 auto;
 }
+.form-group.inline .unit{
+  margin-left:0.25rem;
+  white-space:nowrap;
+}
 
 /* Flexbox wrapper dla kontenerów */
 .wrapper{


### PR DESCRIPTION
## Summary
- adjust weight, sodium and potassium inputs to show units on the right
- show daily requirement column and values for sodium and potassium
- calculate sodium and potassium requirements as 0.5–2 mmol/kg
- remove `/dobę` from requirement values and tweak styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884a311d094832e9fd702986d1d21ed