### PR TITLE
Adjust width for electrolyte inputs

### DIFF
--- a/style.css
+++ b/style.css
@@ -87,6 +87,12 @@ body{
   width:5rem;
   flex:0 0 auto;
 }
+
+#weight,
+#sodium,
+#potassium {
+  width:4rem;
+}
 .form-group.inline .unit{
   margin-left:0.25rem;
   white-space:nowrap;


### PR DESCRIPTION
## Summary
- narrow the mass, sodium, and potassium inputs in the left panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884b1aab610832eb36b1a3628ff33ce