### PR TITLE
Sum additive kcal without XLSX changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
         </thead>
         <tbody>
           <tr>
-            <td>Kalorie</td>
+            <td>Kalorie (łącznie)</td>
             <td><span id="bagCalories"></span> kcal</td>
             <td>&ndash;</td>
             <td><span id="calReqMin">0</span> - <span id="calReqMax">0</span> kcal</td>

--- a/script.js
+++ b/script.js
@@ -42,6 +42,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   const parseNum = val => parseFloat(String(val).replace(/,/g, '.'));
 
   const kcalSpan = $("bagCalories");
+  const additiveKcalPerMl = {
+    add6: 0.8,   // Dipeptiven: 80 kcal/100 ml
+    add8: 1.12   // Omegaven: 112 kcal/100 ml
+  };
   const reqMin   = $("reqMin");
   const reqMax   = $("reqMax");
   const reqAbs   = $("reqAbsMax");
@@ -65,6 +69,19 @@ document.addEventListener("DOMContentLoaded", async () => {
   const kReqMin  = $("kReqMin");
   const kReqMax  = $("kReqMax");
 
+  const updateKcal = () => {
+    const vol = parseInt(volSel.value, 10);
+    const bagInfo = (bagConfig[currentBag()] || []).find(b => b.vol === vol);
+    const bagKcal = bagInfo ? bagInfo.kcal : parseFloat(volSel.selectedOptions[0]?.dataset.kcal) || 0;
+    let total = bagKcal;
+    for (const [id, perMl] of Object.entries(additiveKcalPerMl)) {
+      const el = $(id);
+      if (el) total += (parseNum(el.value) || 0) * perMl;
+    }
+    kcalSpan.textContent = total ? Math.round(total) : "";
+  };
+
+
   const additiveInputs = {
     "Soluvit N": $("add3"),
     "Vitalipid N Adult": $("add4"),
@@ -84,6 +101,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   ["add10", "add17"].forEach(id => {
     const el = $(id);
     if (el) el.addEventListener("input", updateElectrolyteSummary);
+  });
+
+  ["add6", "add8"].forEach(id => {
+    const el = $(id);
+    if (el) el.addEventListener("input", updateKcal);
   });
 
   /* ---------- 3. Inicjalizacja dat ---------- */
@@ -174,8 +196,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     updateElectrolyteSummary();
   }
 
-  const updateKcal = () =>
-    kcalSpan.textContent = volSel.selectedOptions[0]?.dataset.kcal || "";
 
   const updateDosage = () => {
     const cfgDose = dosageConfig[currentBag()];


### PR DESCRIPTION
## Summary
- total kcal now includes Dipeptiven and Omegaven values
- update kcal when those additive fields change
- leave XLSX generator unchanged by reverting previous edit
- fix ReferenceError by defining `updateKcal` before listeners

## Testing
- `node --check script.js`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688a91123084832e98b2cbf07d44cee0