### PR TITLE
Use kg-based Omegaven limits

### DIFF
--- a/config.json
+++ b/config.json
@@ -50,7 +50,7 @@
       }
     },
 
-  
+
     "additiveRangeConfig": {
       "Kabiven": {
         "1026": { "di": [0, 100], "so": [0, 1], "vi": [0, 10], "om": [0, 50]  },
@@ -114,7 +114,7 @@
       "SmofKabiven Peripheral": { "min": 20, "max": 40, "maxDaily": 40 },
       "Kabiven Peripheral":     { "min": 27, "max": 40, "maxDaily": 40 }
     },
-  
+
     "constants": {
       "DIPEPTIVEN_PER_KG": 2.5,
       "OMEGAVEN_PER_KG":   2.0,

--- a/script.js
+++ b/script.js
@@ -117,7 +117,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       );
       rangeOm.textContent = `0 – ${omMax} ml`;
     } else {
-      rangeOm.textContent = "Brak danych";
+      const omMax = w ? Math.round(OMEGAVEN_PER_KG * w) : Infinity;
+      rangeOm.textContent = omMax === Infinity ? "Brak danych" : `0 – ${omMax} ml`;
     }
 
     rangeAd.textContent  = ADDAMEL_RANGE;


### PR DESCRIPTION
## Summary
- compute Omegaven maximum from body weight for all bags
- cap Kabiven Omegaven dose at the bag-specific maximum
- clean up whitespace in `config.json`

## Testing
- `node -e "require('./config.json'); console.log('JSON OK')"`

------
https://chatgpt.com/codex/tasks/task_e_688a90aff7d0832ea5fb2b82ec734b24