### PR TITLE
Prepare PN generator for production

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <!-- FileSaver do pobierania pliku -->
   <script src="https://cdn.jsdelivr.net/npm/file-saver@2.0.5/dist/FileSaver.min.js"></script>
 
+  <script src="pnCalculator.js" defer></script>
   <script src="script.js" defer></script>
   <script src="xlsxGenerator.js" defer></script>
 
@@ -22,48 +23,49 @@
     <!-- ▼▼ 1. LEWY KONTENER – dane pacjenta ▼▼ -->
     <div class="container">
       <h1>Recepta żywienia parenteralnego</h1>
-      <form id="daneForm">
+      <form id="daneForm" autocomplete="off">
 
         <div class="form-group">
           <label for="fullname">Imię i nazwisko</label>
-          <input type="text" id="fullname" value="Jan Kowalski">
+          <input type="text" id="fullname" required>
         </div>
 
         <div class="form-group">
           <label for="pesel">PESEL</label>
-          <input type="text" id="pesel" value="80010112345">
+          <input type="text" id="pesel" inputmode="numeric" pattern="\d{11}" maxlength="11" required>
           <hr class="divider">
         </div>
 
         <div class="form-group">
           <label for="dateFrom">Data wystawienia</label>
-          <input type="date" id="dateFrom">
+          <input type="date" id="dateFrom" required>
         </div>
         <div class="form-group">
           <label for="dateTo">Data podania</label>
-          <input type="date" id="dateTo">
+          <input type="date" id="dateTo" required>
         </div>
 
         <div class="form-group inline">
           <label for="weight">Masa ciała</label>
-          <input type="text" id="weight" value="70">
+          <input type="text" id="weight" inputmode="decimal" required>
           <span class="unit">kg</span>
         </div>
 
 
         <div class="form-group inline">
           <label for="sodium">Sód</label>
-          <input type="text" id="sodium" value="140">
+          <input type="text" id="sodium" inputmode="decimal">
           <span class="unit">mmol/L</span>
         </div>
 
         <div class="form-group inline">
           <label for="potassium">Potas</label>
-          <input type="text" id="potassium" value="3.5">
+          <input type="text" id="potassium" inputmode="decimal">
           <span class="unit">mmol/L</span>
         </div>
 
       </form>
+      <p class="safety-note">Narzędzie pomocnicze. Ostateczną receptę i zgodność z aktualnymi ChPL oraz stanem klinicznym pacjenta musi zweryfikować uprawniony personel medyczny.</p>
     </div>
     <!-- ▲▲ 1. LEWY KONTENER ▲▲ -->
 
@@ -104,7 +106,7 @@
 
         <tr>
           <td class="label">Glycophos fiol. 20 ml<div class="sub">Fosforan organiczny (glicerofosforan sodowy)</div></td>
-          <td class="input"><input type="text" id="add1" placeholder="ml"></td><td></td>
+          <td class="input"><input type="text" id="add1" placeholder="ml" inputmode="decimal"></td><td></td>
         </tr>
 
         <!-- zmieniona etykieta KCl -->
@@ -113,12 +115,12 @@
             KCl 15% amp. 10/20 ml
             <div class="sub">20&nbsp;mmol K<sup>+</sup>/10&nbsp;ml</div>
           </td>
-          <td class="input"><input type="text" id="add10" placeholder="ml"></td><td></td>
+          <td class="input"><input type="text" id="add10" placeholder="ml" inputmode="decimal"></td><td></td>
         </tr>
 
-        <tr><td class="label">Calcium chloratum 10 % amp. 10 ml</td><td class="input"><input type="text" id="add12" placeholder="ml"></td><td></td></tr>
-        <tr><td class="label">Calcium glubionas 10 % amp. 10 ml</td><td class="input"><input type="text" id="add13" placeholder="ml"></td><td></td></tr>
-        <tr><td class="label">Magnesi sulf. 20 % amp. 10 ml</td><td class="input"><input type="text" id="add14" placeholder="ml"></td><td></td></tr>
+        <tr><td class="label">Calcium chloratum 10 % amp. 10 ml</td><td class="input"><input type="text" id="add12" placeholder="ml" inputmode="decimal"></td><td></td></tr>
+        <tr><td class="label">Calcium glubionas 10 % amp. 10 ml</td><td class="input"><input type="text" id="add13" placeholder="ml" inputmode="decimal"></td><td></td></tr>
+        <tr><td class="label">Magnesi sulf. 20 % amp. 10 ml</td><td class="input"><input type="text" id="add14" placeholder="ml" inputmode="decimal"></td><td></td></tr>
 
         <!-- zmieniona etykieta NaCl -->
         <tr>
@@ -126,7 +128,7 @@
             NaCl 0,9% amp. 10 ml
             <div class="sub">15,4&nbsp;mmol Na<sup>+</sup>/10&nbsp;ml</div>
           </td>
-          <td class="input"><input type="text" id="add17" placeholder="ml"></td><td></td>
+          <td class="input"><input type="text" id="add17" placeholder="ml" inputmode="decimal"></td><td></td>
         </tr>
 
         <tr>
@@ -134,7 +136,7 @@
             Addamel N amp. 10 ml
             <div class="sub">Pierwiastki śladowe, ostrożnie przy cholestazie i&nbsp;PChN</div>
           </td>
-          <td class="input"><input type="text" id="add2" placeholder="ml"></td>
+          <td class="input"><input type="text" id="add2" placeholder="ml" inputmode="decimal"></td>
           <td class="range" id="rangeAdd2">0 – 10 ml</td>
         </tr>
 
@@ -143,19 +145,19 @@
 
         <tr>
           <td class="label">Soluvit N fiol.<div class="sub">Witaminy rozpuszczalne w wodzie</div></td>
-          <td class="input"><input type="text" id="add3" placeholder="ilość fiolek"></td>
+          <td class="input"><input type="text" id="add3" placeholder="ilość fiolek" inputmode="decimal"></td>
           <td class="range" id="rangeAdd3"></td>
         </tr>
 
         <tr>
           <td class="label">Vitalipid N Adult amp. 10 ml<div class="sub">Witaminy rozpuszczalne w tłuszczach (ADEK)</div></td>
-          <td class="input"><input type="text" id="add4" placeholder="ml"></td>
+          <td class="input"><input type="text" id="add4" placeholder="ml" inputmode="decimal"></td>
           <td class="range" id="rangeAdd4"></td>
         </tr>
 
         <tr style="display:none;">
           <td class="label">Vitalipid N Infant amp. 10 ml<div class="sub">Witaminy rozpuszczalne w tłuszczach (ADEK)</div></td>
-          <td class="input"><input type="text" id="add5" placeholder="ml"></td><td></td>
+          <td class="input"><input type="text" id="add5" placeholder="ml" inputmode="decimal"></td><td></td>
         </tr>
 
         <tr>
@@ -163,7 +165,7 @@
             Vit. B1 50 mg/ml amp. 2 ml
             <div class="sub">Refeeding syndrome, alkoholizm, długie niedożywienie</div>
           </td>
-          <td class="input"><input type="text" id="add15" placeholder="ml"></td>
+          <td class="input"><input type="text" id="add15" placeholder="ml" inputmode="decimal"></td>
           <td class="range" id="rangeAdd15">0 – 6 ml</td>
         </tr>
 
@@ -172,7 +174,7 @@
             Vit. C 100 mg/ml amp. 5 ml
             <div class="sub">Sepsa, rozległe oparzenia, dializa</div>
           </td>
-          <td class="input"><input type="text" id="add16" placeholder="ml"></td>
+          <td class="input"><input type="text" id="add16" placeholder="ml" inputmode="decimal"></td>
           <td class="range" id="rangeAdd16">0 – 20 ml (max. 30 ml)</td>
         </tr>
 
@@ -181,13 +183,13 @@
 
         <tr>
           <td class="label">Dipeptiven but. 50/100 ml<div class="sub">Związek białkowy</div></td>
-          <td class="input"><input type="text" id="add6" placeholder="ml"></td>
+          <td class="input"><input type="text" id="add6" placeholder="ml" inputmode="decimal"></td>
           <td class="range" id="rangeAdd6"></td>
         </tr>
 
         <tr>
           <td class="label">Omegaven but. 50/100 ml<div class="sub">Kwasy omega-3</div></td>
-          <td class="input"><input type="text" id="add8" placeholder="ml"></td>
+          <td class="input"><input type="text" id="add8" placeholder="ml" inputmode="decimal"></td>
           <td class="range" id="rangeAdd8"></td>
         </tr>
       </table>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "parenteral-nutrition-generator",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Generator recepty żywienia parenteralnego z walidacją danych i testami jednostkowymi.",
+  "scripts": {
+    "test": "node --test",
+    "check:syntax": "node --check script.js && node --check xlsxGenerator.js && node --check pnCalculator.js"
+  },
+  "devDependencies": {}
+}

--- a/pnCalculator.js
+++ b/pnCalculator.js
@@ -1,0 +1,188 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  root.PNCalculator = api;
+})(typeof globalThis !== "undefined" ? globalThis : window, function () {
+  const ADDITIVE_KCAL_PER_ML = {
+    add6: 0.8,
+    add8: 1.12
+  };
+
+  function parseNumber (value) {
+    if (value === null || value === undefined) return NaN;
+    if (typeof value === "number") return Number.isFinite(value) ? value : NaN;
+    const normalized = String(value).trim().replace(/,/g, ".");
+    if (normalized === "") return NaN;
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  }
+
+  function formatRange (min, max, unit) {
+    return `${min} – ${max} ${unit}`;
+  }
+
+  function getCurrentBag (productType, nutritionType) {
+    return nutritionType === "obwodowe" ? `${productType} Peripheral` : productType;
+  }
+
+  function getBagInfo (bagConfig, bag, volume) {
+    const numericVolume = Number(volume);
+    return (bagConfig[bag] || []).find(item => Number(item.vol) === numericVolume) || null;
+  }
+
+  function calculateTotalKcal ({ bagConfig, bag, volume, additives = {} }) {
+    const info = getBagInfo(bagConfig, bag, volume);
+    let total = info ? Number(info.kcal) : 0;
+    for (const [id, kcalPerMl] of Object.entries(ADDITIVE_KCAL_PER_ML)) {
+      total += (parseNumber(additives[id]) || 0) * kcalPerMl;
+    }
+    return total ? Math.round(total) : 0;
+  }
+
+  function calculateAdditiveRanges ({ additiveRangeConfig, constants, bag, volume, weight }) {
+    const cfgRange = additiveRangeConfig[bag]?.[Number(volume)];
+    const numericWeight = parseNumber(weight) || 0;
+    const weightLimited = (perKg, fallbackMax = Infinity) => Math.min(
+      fallbackMax,
+      numericWeight ? Math.round(perKg * numericWeight) : Infinity
+    );
+
+    const diMax = weightLimited(constants.DIPEPTIVEN_PER_KG, cfgRange?.di?.[1] ?? Infinity);
+    const omMax = weightLimited(constants.OMEGAVEN_PER_KG, cfgRange?.om?.[1] ?? Infinity);
+
+    return {
+      di: { min: 0, max: diMax, label: diMax === Infinity ? "Brak danych" : formatRange(0, diMax, "ml") },
+      om: { min: 0, max: omMax, label: omMax === Infinity ? "Brak danych" : formatRange(0, omMax, "ml") },
+      so: cfgRange?.so
+        ? { min: cfgRange.so[0], max: cfgRange.so[1], label: formatRange(cfgRange.so[0], cfgRange.so[1], "fiol.") }
+        : { min: null, max: null, label: "Brak danych" },
+      vi: cfgRange?.vi
+        ? { min: cfgRange.vi[0], max: cfgRange.vi[1], label: formatRange(cfgRange.vi[0], cfgRange.vi[1], "ml") }
+        : { min: null, max: null, label: "Brak danych" },
+      ad: { min: 0, max: 10, label: constants.ADDAMEL_RANGE },
+      vb1: { min: 0, max: 6, label: constants.VIT_B1_RANGE },
+      vc: { min: 0, max: 20, hardMax: 30, label: constants.VIT_C_RANGE }
+    };
+  }
+
+  function calculateElectrolyteSummary ({ electrolyteConfig, bag, volume, sodiumChlorideMl, potassiumChlorideMl }) {
+    const eCfg = electrolyteConfig?.[bag]?.[Number(volume)] || {};
+    const sodium = (eCfg.Na || 0) + ((parseNumber(sodiumChlorideMl) || 0) * 1.54);
+    const potassium = (eCfg.K || 0) + ((parseNumber(potassiumChlorideMl) || 0) * 2);
+    return {
+      sodium: Math.round(sodium),
+      potassium: Math.round(potassium),
+      sodiumMax: eCfg.NaMax || 0,
+      potassiumMax: eCfg.KMax || 0
+    };
+  }
+
+  function calculateRequirements ({ dosageConfig, bag, weight }) {
+    const cfgDose = dosageConfig[bag];
+    const numericWeight = parseNumber(weight) || 0;
+    if (!numericWeight) {
+      return {
+        calories: { min: 0, max: 0 },
+        sodium: { min: 0, max: 0 },
+        potassium: { min: 0, max: 0 },
+        volume: { min: 0, max: 0, absoluteMax: 0 }
+      };
+    }
+    return {
+      calories: { min: Math.round(25 * numericWeight), max: Math.round(35 * numericWeight) },
+      sodium: { min: Math.round(0.5 * numericWeight), max: Math.round(2 * numericWeight) },
+      potassium: { min: Math.round(0.5 * numericWeight), max: Math.round(2 * numericWeight) },
+      volume: {
+        min: cfgDose ? Math.round(cfgDose.min * numericWeight) : 0,
+        max: cfgDose ? Math.round(cfgDose.max * numericWeight) : 0,
+        absoluteMax: cfgDose ? Math.round(cfgDose.maxDaily * numericWeight) : 0
+      }
+    };
+  }
+
+  function validatePesel (pesel) {
+    const value = String(pesel || "").trim();
+    if (!/^\d{11}$/.test(value)) return false;
+    const weights = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3];
+    const sum = weights.reduce((acc, weight, index) => acc + (Number(value[index]) * weight), 0);
+    return ((10 - (sum % 10)) % 10) === Number(value[10]);
+  }
+
+  function collectRangeErrors (errors, additivesById, ranges) {
+    const checks = [
+      ["add6", "Dipeptiven", ranges.di.max],
+      ["add8", "Omegaven", ranges.om.max],
+      ["add3", "Soluvit N", ranges.so.max],
+      ["add4", "Vitalipid N Adult", ranges.vi.max],
+      ["add2", "Addamel N", ranges.ad.max],
+      ["add15", "Vit. B1", ranges.vb1.max],
+      ["add16", "Vit. C", ranges.vc.hardMax]
+    ];
+
+    checks.forEach(([id, label, max]) => {
+      const value = parseNumber(additivesById[id]);
+      if (!Number.isNaN(value) && max !== null && max !== Infinity && value > max) {
+        errors.push(`${label}: przekroczono maksymalną wartość ${max}.`);
+      }
+    });
+  }
+
+  function validateRecipe ({ cfg, productType, nutritionType, bag, volume, weight, name, pesel, dateFrom, dateTo, additivesById = {} }) {
+    const errors = [];
+    const numericWeight = parseNumber(weight);
+    if (!String(name || "").trim()) errors.push("Uzupełnij imię i nazwisko pacjenta.");
+    if (!validatePesel(pesel)) errors.push("PESEL ma nieprawidłowy format lub sumę kontrolną.");
+    if (!dateFrom) errors.push("Uzupełnij datę wystawienia.");
+    if (!dateTo) errors.push("Uzupełnij datę podania.");
+    if (dateFrom && dateTo && dateTo < dateFrom) errors.push("Data podania nie może być wcześniejsza niż data wystawienia.");
+    if (!Number.isFinite(numericWeight) || numericWeight <= 0) errors.push("Masa ciała musi być dodatnią liczbą.");
+    if (!cfg.bagConfig[bag]) errors.push("Wybrano nieobsługiwany typ worka.");
+    if (!getBagInfo(cfg.bagConfig, bag, volume)) errors.push("Wybrano nieobsługiwaną objętość worka.");
+
+    Object.entries(additivesById).forEach(([id, value]) => {
+      const raw = String(value ?? "").trim();
+      if (raw && !Number.isFinite(parseNumber(raw))) errors.push(`Dodatek ${id} musi być liczbą.`);
+      if (Number.isFinite(parseNumber(raw)) && parseNumber(raw) < 0) errors.push(`Dodatek ${id} nie może być ujemny.`);
+    });
+
+    if (errors.length === 0) {
+      const ranges = calculateAdditiveRanges({
+        additiveRangeConfig: cfg.additiveRangeConfig,
+        constants: cfg.constants,
+        bag,
+        volume,
+        weight: numericWeight
+      });
+      collectRangeErrors(errors, additivesById, ranges);
+
+      const electrolytes = calculateElectrolyteSummary({
+        electrolyteConfig: cfg.electrolyteConfig,
+        bag,
+        volume,
+        sodiumChlorideMl: additivesById.add17,
+        potassiumChlorideMl: additivesById.add10
+      });
+      if (electrolytes.sodiumMax && electrolytes.sodium > electrolytes.sodiumMax) {
+        errors.push(`Sód w mieszaninie (${electrolytes.sodium} mmol) przekracza limit worka ${electrolytes.sodiumMax} mmol.`);
+      }
+      if (electrolytes.potassiumMax && electrolytes.potassium > electrolytes.potassiumMax) {
+        errors.push(`Potas w mieszaninie (${electrolytes.potassium} mmol) przekracza limit worka ${electrolytes.potassiumMax} mmol.`);
+      }
+    }
+
+    return { valid: errors.length === 0, errors, productType, nutritionType };
+  }
+
+  return {
+    ADDITIVE_KCAL_PER_ML,
+    parseNumber,
+    getCurrentBag,
+    getBagInfo,
+    calculateTotalKcal,
+    calculateAdditiveRanges,
+    calculateElectrolyteSummary,
+    calculateRequirements,
+    validatePesel,
+    validateRecipe
+  };
+});

--- a/script.js
+++ b/script.js
@@ -39,7 +39,14 @@ document.addEventListener("DOMContentLoaded", async () => {
   const weightInp  = $("weight");
   const volSel     = $("bagVolume");
 
-  const parseNum = val => parseFloat(String(val).replace(/,/g, '.'));
+  const {
+    parseNumber: parseNum,
+    calculateTotalKcal,
+    calculateAdditiveRanges,
+    calculateElectrolyteSummary,
+    calculateRequirements,
+    validateRecipe
+  } = PNCalculator;
 
   const kcalSpan = $("bagCalories");
   const additiveKcalPerMl = {
@@ -70,15 +77,14 @@ document.addEventListener("DOMContentLoaded", async () => {
   const kReqMax  = $("kReqMax");
 
   const updateKcal = () => {
-    const vol = parseInt(volSel.value, 10);
-    const bagInfo = (bagConfig[currentBag()] || []).find(b => b.vol === vol);
-    const bagKcal = bagInfo ? bagInfo.kcal : parseFloat(volSel.selectedOptions[0]?.dataset.kcal) || 0;
-    let total = bagKcal;
-    for (const [id, perMl] of Object.entries(additiveKcalPerMl)) {
-      const el = $(id);
-      if (el) total += (parseNum(el.value) || 0) * perMl;
-    }
-    kcalSpan.textContent = total ? Math.round(total) : "";
+    const additives = Object.fromEntries(Object.keys(additiveKcalPerMl).map(id => [id, $(id)?.value]));
+    const total = calculateTotalKcal({
+      bagConfig,
+      bag: currentBag(),
+      volume: volSel.value,
+      additives
+    });
+    kcalSpan.textContent = total || "";
   };
 
 
@@ -123,31 +129,21 @@ document.addEventListener("DOMContentLoaded", async () => {
   function updateAdditiveRanges () {
     const bag = currentBag();
     const vol = parseInt(volSel.value, 10);
-    const cfgRange = additiveRangeConfig[bag]?.[vol];
-    const w = parseNum(weightInp.value) || 0;
+    const ranges = calculateAdditiveRanges({
+      additiveRangeConfig,
+      constants: { DIPEPTIVEN_PER_KG, OMEGAVEN_PER_KG, ADDAMEL_RANGE, VIT_B1_RANGE, VIT_C_RANGE },
+      bag,
+      volume: vol,
+      weight: weightInp.value
+    });
 
-    const diMax = Math.min(
-      cfgRange?.di ? cfgRange.di[1] : Infinity,
-        w ? Math.round(DIPEPTIVEN_PER_KG * w) : Infinity
-    );
-    rangeDi.textContent = diMax === Infinity ? "Brak danych" : `0 – ${diMax} ml`;
-
-    if (cfgRange?.om) {
-      const omMax = Math.min(
-        cfgRange.om[1],
-        w ? Math.round(OMEGAVEN_PER_KG * w) : Infinity
-      );
-      rangeOm.textContent = `0 – ${omMax} ml`;
-    } else {
-      const omMax = w ? Math.round(OMEGAVEN_PER_KG * w) : Infinity;
-      rangeOm.textContent = omMax === Infinity ? "Brak danych" : `0 – ${omMax} ml`;
-    }
-
-    rangeAd.textContent  = ADDAMEL_RANGE;
-    rangeSo.textContent  = cfgRange ? `${cfgRange.so[0]} – ${cfgRange.so[1]} fiol.` : "Brak danych";
-    rangeVi.textContent  = cfgRange ? `${cfgRange.vi[0]} – ${cfgRange.vi[1]} ml`   : "Brak danych";
-    rangeVb1.textContent = VIT_B1_RANGE;
-    rangeVc.textContent  = VIT_C_RANGE;
+    rangeDi.textContent  = ranges.di.label;
+    rangeOm.textContent  = ranges.om.label;
+    rangeAd.textContent  = ranges.ad.label;
+    rangeSo.textContent  = ranges.so.label;
+    rangeVi.textContent  = ranges.vi.label;
+    rangeVb1.textContent = ranges.vb1.label;
+    rangeVc.textContent  = ranges.vc.label;
   }
 
   function applyDefaultAdditives () {
@@ -162,19 +158,17 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   /* --- podsumowanie Na i K --- */
   function updateElectrolyteSummary () {
-    const bag = currentBag();
-    const vol = parseInt(volSel.value, 10);
-    const eCfg = cfg.electrolyteConfig?.[bag]?.[vol] || {};
-    let na = eCfg.Na || 0;
-    let k  = eCfg.K  || 0;
-    const addNa = parseNum($("add17").value) || 0; // NaCl
-    const addK  = parseNum($("add10").value) || 0; // KCl
-    na += addNa * 1.54;
-    k  += addK  * 2;
-    naTotal.textContent = Math.round(na);
-    kTotal.textContent  = Math.round(k);
-    naMaxSpan.textContent = eCfg.NaMax || 0;
-    kMaxSpan.textContent  = eCfg.KMax || 0;
+    const summary = calculateElectrolyteSummary({
+      electrolyteConfig: cfg.electrolyteConfig,
+      bag: currentBag(),
+      volume: volSel.value,
+      sodiumChlorideMl: $("add17").value,
+      potassiumChlorideMl: $("add10").value
+    });
+    naTotal.textContent = summary.sodium;
+    kTotal.textContent  = summary.potassium;
+    naMaxSpan.textContent = summary.sodiumMax;
+    kMaxSpan.textContent  = summary.potassiumMax;
   }
 
   /* --- worki & kcal --- */
@@ -199,28 +193,20 @@ document.addEventListener("DOMContentLoaded", async () => {
 
 
   const updateDosage = () => {
-    const cfgDose = dosageConfig[currentBag()];
-    const w = parseNum(weightInp.value) || 0;
-    if (w) {
-      calReqMin.textContent = Math.round(25 * w);
-      calReqMax.textContent = Math.round(35 * w);
-      naReqMin.textContent = Math.round(0.5 * w);
-      naReqMax.textContent = Math.round(2 * w);
-      kReqMin.textContent  = Math.round(0.5 * w);
-      kReqMax.textContent  = Math.round(2 * w);
-    } else {
-      calReqMin.textContent = calReqMax.textContent = "0";
-      naReqMin.textContent = naReqMax.textContent = "0";
-      kReqMin.textContent  = kReqMax.textContent  = "0";
-    }
-
-    if (cfgDose && w) {
-      reqMin.textContent = Math.round(cfgDose.min * w);
-      reqMax.textContent = Math.round(cfgDose.max * w);
-      reqAbs.textContent = Math.round(cfgDose.maxDaily * w);
-    } else {
-      reqMin.textContent = reqMax.textContent = reqAbs.textContent = "0";
-    }
+    const requirements = calculateRequirements({
+      dosageConfig,
+      bag: currentBag(),
+      weight: weightInp.value
+    });
+    calReqMin.textContent = requirements.calories.min;
+    calReqMax.textContent = requirements.calories.max;
+    naReqMin.textContent = requirements.sodium.min;
+    naReqMax.textContent = requirements.sodium.max;
+    kReqMin.textContent  = requirements.potassium.min;
+    kReqMax.textContent  = requirements.potassium.max;
+    reqMin.textContent = requirements.volume.min;
+    reqMax.textContent = requirements.volume.max;
+    reqAbs.textContent = requirements.volume.absoluteMax;
   };
 
   /* --- eventy UI --- */
@@ -272,6 +258,29 @@ document.addEventListener("DOMContentLoaded", async () => {
     split(5, 6, 100);
     split(7, 8, 100);
     split(9, 10, 20);
+
+    const additivesById = Object.fromEntries(
+      Array.from({ length: 17 }, (_, i) => [`add${i + 1}`, $(`add${i + 1}`)?.value || ""])
+    );
+
+    const validation = validateRecipe({
+      cfg,
+      productType: productSel.value,
+      nutritionType: nutritSel.value,
+      bag: currentBag(),
+      volume: volSel.value,
+      weight: weightInp.value,
+      name: data.name,
+      pesel: data.pesel,
+      dateFrom: data.dateFrom,
+      dateTo: data.dateTo,
+      additivesById
+    });
+
+    if (!validation.valid) {
+      alert(`Popraw dane przed wygenerowaniem recepty:\n\n${validation.errors.join("\n")}`);
+      return;
+    }
 
     /* flaga centralne/obwodowe */
     const central = nutritSel.value === "centralne";

--- a/style.css
+++ b/style.css
@@ -260,3 +260,14 @@ button:hover{background-color:#005fa3;}
   flex:1;
   margin-bottom:0;
 }
+
+.safety-note{
+  margin-top:1rem;
+  font-size:0.8rem;
+  line-height:1.35;
+  color:#6b4e00;
+  background:#fff8db;
+  border:1px solid #f0d98c;
+  border-radius:4px;
+  padding:0.75rem;
+}

--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -1,0 +1,123 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const calc = require('../pnCalculator.js');
+const cfg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'config.json'), 'utf8'));
+
+test('parseNumber accepts Polish decimal comma and rejects malformed values', () => {
+  assert.equal(calc.parseNumber('3,5'), 3.5);
+  assert.equal(calc.parseNumber(' 12.25 '), 12.25);
+  assert.equal(Number.isNaN(calc.parseNumber('12abc')), true);
+});
+
+test('getCurrentBag maps peripheral nutrition to Peripheral product variant', () => {
+  assert.equal(calc.getCurrentBag('SmofKabiven', 'obwodowe'), 'SmofKabiven Peripheral');
+  assert.equal(calc.getCurrentBag('Kabiven', 'centralne'), 'Kabiven');
+});
+
+test('calculateTotalKcal includes bag calories plus Dipeptiven and Omegaven calories', () => {
+  assert.equal(calc.calculateTotalKcal({
+    bagConfig: cfg.bagConfig,
+    bag: 'SmofKabiven Peripheral',
+    volume: 1206,
+    additives: { add6: '50', add8: '25' }
+  }), 868);
+});
+
+test('calculateAdditiveRanges limits Dipeptiven and Omegaven by both bag and patient weight', () => {
+  const ranges = calc.calculateAdditiveRanges({
+    additiveRangeConfig: cfg.additiveRangeConfig,
+    constants: cfg.constants,
+    bag: 'Kabiven',
+    volume: 1026,
+    weight: 30
+  });
+  assert.equal(ranges.di.max, 75);
+  assert.equal(ranges.om.max, 50);
+  assert.equal(ranges.so.label, '0 – 1 fiol.');
+});
+
+test('calculateElectrolyteSummary adds NaCl and KCl in mmol from ml', () => {
+  assert.deepEqual(calc.calculateElectrolyteSummary({
+    electrolyteConfig: cfg.electrolyteConfig,
+    bag: 'Kabiven',
+    volume: 1026,
+    sodiumChlorideMl: 10,
+    potassiumChlorideMl: 10
+  }), {
+    sodium: 47,
+    potassium: 44,
+    sodiumMax: 154,
+    potassiumMax: 154
+  });
+});
+
+test('calculateRequirements returns clinical daily ranges based on weight', () => {
+  assert.deepEqual(calc.calculateRequirements({
+    dosageConfig: cfg.dosageConfig,
+    bag: 'SmofKabiven Peripheral',
+    weight: 70
+  }), {
+    calories: { min: 1750, max: 2450 },
+    sodium: { min: 35, max: 140 },
+    potassium: { min: 35, max: 140 },
+    volume: { min: 1400, max: 2800, absoluteMax: 2800 }
+  });
+});
+
+test('validatePesel validates checksum', () => {
+  assert.equal(calc.validatePesel('44051401458'), true);
+  assert.equal(calc.validatePesel('44051401459'), false);
+});
+
+test('validateRecipe blocks invalid clinical and production inputs', () => {
+  const result = calc.validateRecipe({
+    cfg,
+    productType: 'SmofKabiven',
+    nutritionType: 'obwodowe',
+    bag: 'SmofKabiven Peripheral',
+    volume: 1206,
+    weight: 30,
+    name: 'Jan Testowy',
+    pesel: '44051401458',
+    dateFrom: '2026-06-05',
+    dateTo: '2026-06-04',
+    additivesById: { add6: '100', add8: '500', add10: '100', add17: '200' }
+  });
+
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join('\n'), /Data podania/);
+});
+
+test('validateRecipe catches exceeded potassium bag limit', () => {
+  const result = calc.validateRecipe({
+    cfg,
+    productType: 'Kabiven',
+    nutritionType: 'centralne',
+    bag: 'Kabiven',
+    volume: 1026,
+    weight: 70,
+    name: 'Jan Testowy',
+    pesel: '44051401458',
+    dateFrom: '2026-06-05',
+    dateTo: '2026-06-05',
+    additivesById: { add10: '100', add17: '0' }
+  });
+
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join('\n'), /Potas w mieszaninie/);
+});
+
+test('configuration has complete electrolyte, additive range and dosage data for every selectable bag', () => {
+  for (const [bag, bags] of Object.entries(cfg.bagConfig)) {
+    assert.ok(cfg.electrolyteConfig[bag], `missing electrolyte config for ${bag}`);
+    assert.ok(cfg.additiveRangeConfig[bag], `missing additive range config for ${bag}`);
+    assert.ok(cfg.dosageConfig[bag], `missing dosage config for ${bag}`);
+    for (const { vol } of bags) {
+      assert.ok(cfg.electrolyteConfig[bag][vol], `missing electrolyte config for ${bag} ${vol}`);
+      assert.ok(cfg.additiveRangeConfig[bag][vol], `missing additive ranges for ${bag} ${vol}`);
+    }
+  }
+});

--- a/xlsxGenerator.js
+++ b/xlsxGenerator.js
@@ -89,7 +89,8 @@ async function generateRecipeXlsx ({ data, currentBag, central, cfg }) {
       const finalBlob = await zip.generateAsync({ type: "blob" });
       const bagLabel   = currentBag.replace(" Peripheral", "");
       const routeLabel = central ? "centralne" : "obwodowe";
-      const fileName   = `${data.name} ${bagLabel} ${routeLabel}.xlsx`;
+      const safePatient = (data.name || "pacjent").replace(/[\\/:*?"<>|]+/g, " ").replace(/\s+/g, " ").trim();
+      const fileName   = `${safePatient} ${bagLabel} ${routeLabel}.xlsx`;
       saveAs(finalBlob, fileName);
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
### Motivation
- Zrefaktoryzować logikę obliczeń i walidacji do modułu wielokrotnego użytku oraz wprowadzić sprawdzenia gotowe do użytku produkcyjnego. 
- Zapobiec generowaniu recept z nieprawidłowymi danymi klinicznymi lub przekroczeniami limitów worka/elektrolitów.
- Ułatwić automatyczne testowanie i utrzymanie przez dodanie testów jednostkowych i skryptów sprawdzających poprawność składni.

### Description
- Dodano nowy moduł `pnCalculator.js` eksportujący funkcje: `parseNumber`, `calculateTotalKcal`, `calculateAdditiveRanges`, `calculateElectrolyteSummary`, `calculateRequirements`, `validatePesel` i `validateRecipe` oraz pomocnicze stałe. 
- Zmieniono `script.js`, aby używać `PNCalculator` (obliczenia kcal, zakresy dodatków, podsumowanie elektrolitów, zapotrzebowanie) i dodać walidację formularza przed wywołaniem eksportu. 
- Zmodyfikowano `index.html` (usunieto przykładowe dane, dodano `required`, `autocomplete="off"`, `inputmode`/pattern/maxlength dla pól liczbowych i PESEL oraz notę bezpieczeństwa) i `style.css` (styling noty). 
- Zabezpieczono nazwę pliku XLSX przed niedozwolonymi znakami w `xlsxGenerator.js`. 
- Dodano `package.json` oraz testy jednostkowe `test/pnCalculator.test.js` obejmujące parsowanie, obliczenia, zakresy, walidację PESEL i reguły biznesowe konfiguracji.

### Testing
- Uruchomiono `npm test` — wszystkie testy jednostkowe przeszły pomyślnie (`10 passed`).
- Uruchomiono `npm run check:syntax` — sprawdzenie składni plików JS zakończone bez błędów.
- Sprawdzono dostępność stron statycznych przez prosty serwer (`python3 -m http.server`) i pobranie `index.html` oraz `config.json`, operacje zakończone pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2354a59abc832ea63d344fbab7317a)