### PR TITLE
Tighten left panel spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <div class="wrapper">
 
     <!-- ▼▼ 1. LEWY KONTENER – dane pacjenta ▼▼ -->
-    <div class="container">
+    <div class="container patient-data">
       <h1>Recepta żywienia parenteralnego</h1>
       <form id="daneForm">
 

--- a/style.css
+++ b/style.css
@@ -40,11 +40,19 @@ body{
 .divider{
   border:none;
   border-top:1px solid #ccd0d5;
-  margin:2rem -2rem;
+  margin:1.25rem -2rem;
 }
 
 /* Pola formularza */
 .form-group{margin-bottom:1.25rem;}
+
+.patient-data .form-group{
+  margin-bottom:0.8rem;
+}
+
+.patient-data .form-group label{
+  margin-bottom:0.35rem;
+}
 
 .form-group label{
   display:block;


### PR DESCRIPTION
### Motivation
- Make the left (patient data) panel more compact by reducing vertical spacing between fields and labels while keeping changes scoped to that panel.
- Slightly reduce the PESEL divider margin to tighten the layout further.

### Description
- Add the `patient-data` class to the left `.container` in `index.html` to scope spacing changes to that panel only.
- Add scoped CSS rules `.patient-data .form-group` and `.patient-data .form-group label` in `style.css` to reduce vertical gaps between groups and labels.
- Reduce the `.divider` margin in `style.css` from `2rem` to `1.25rem`.

### Testing
- Ran `git diff --check` which reported no issues.
- Served the app with `python3 -m http.server 8000 --bind 127.0.0.1` and verified `curl -fIs http://127.0.0.1:8000/index.html` returned a `200 OK` response.
- Attempted a visual screenshot with `npx playwright ... screenshot`, but it failed because the environment is missing required browser host dependencies, so visual verification via Playwright could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a219948f7c8832eb354dbc3d9ef784c)