### PR TITLE
Add XLSX import for previous recipe with parsing and UI feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,15 @@
           <span class="unit">mmol/L</span>
         </div>
 
+        <hr class="divider">
+
+        <div class="form-group import-recipe">
+          <label for="recipeImport">Wgraj poprzednią receptę</label>
+          <input type="file" id="recipeImport" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">
+          <p class="hint">Wybierz plik XLSX wygenerowany wcześniej w tym programie.</p>
+          <p class="import-status" id="importStatus" aria-live="polite"></p>
+        </div>
+
       </form>
     </div>
     <!-- ▲▲ 1. LEWY KONTENER ▲▲ -->

--- a/script.js
+++ b/script.js
@@ -38,6 +38,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   const nutritSel  = $("nutritionType");
   const weightInp  = $("weight");
   const volSel     = $("bagVolume");
+  const importInp  = $("recipeImport");
+  const importStatus = $("importStatus");
 
   const parseNum = val => parseFloat(String(val).replace(/,/g, '.'));
 
@@ -68,6 +70,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   const naReqMax = $("naReqMax");
   const kReqMin  = $("kReqMin");
   const kReqMax  = $("kReqMax");
+
+  const additiveInputIds = Array.from({ length: 17 }, (_, i) => `add${i + 1}`);
 
   const updateKcal = () => {
     const vol = parseInt(volSel.value, 10);
@@ -118,6 +122,146 @@ document.addEventListener("DOMContentLoaded", async () => {
     nutritSel.value === "obwodowe"
       ? `${productSel.value} Peripheral`
       : productSel.value;
+
+  function showImportStatus (message, type = "info") {
+    if (!importStatus) return;
+    importStatus.textContent = message;
+    importStatus.className = `import-status ${type}`;
+  }
+
+  function getCellPlainValue (ws, address) {
+    const value = ws.getCell(address).value;
+    if (value && typeof value === "object") {
+      if (value instanceof Date) return value;
+      if ("result" in value) return value.result;
+      if ("text" in value) return value.text;
+      if (Array.isArray(value.richText)) return value.richText.map(part => part.text).join("");
+    }
+    return value;
+  }
+
+  function toInputValue (value) {
+    if (value === null || value === undefined) return "";
+    if (value instanceof Date) return value.toISOString().slice(0, 10);
+    return String(value).trim();
+  }
+
+  function excelSerialToDateInput (serial) {
+    if (!Number.isFinite(serial)) return "";
+    const utcDays = Math.floor(serial - 25569);
+    const utcValue = utcDays * 86400 * 1000;
+    return new Date(utcValue).toISOString().slice(0, 10);
+  }
+
+  function toDateInputValue (value) {
+    if (value === null || value === undefined || value === "") return "";
+    if (value instanceof Date) return value.toISOString().slice(0, 10);
+    if (typeof value === "number") return excelSerialToDateInput(value);
+    const text = String(value).trim();
+    if (/^\d{4}-\d{2}-\d{2}$/.test(text)) return text;
+    const parsed = new Date(text);
+    return Number.isNaN(parsed.getTime()) ? text : parsed.toISOString().slice(0, 10);
+  }
+
+  function setAdditiveValue (id, value) {
+    const el = $(id);
+    if (!el) return;
+    el.value = value === 0 ? "" : toInputValue(value);
+    manualAdditives.add(id);
+  }
+
+  function chooseImportedBag (ws) {
+    const rowMap = {
+      "Kabiven": 23,
+      "SmofKabiven": 24,
+      "Kabiven Peripheral": 25,
+      "SmofKabiven Peripheral": 26
+    };
+
+    for (const [bag, row] of Object.entries(rowMap)) {
+      const vol = parseInt(getCellPlainValue(ws, `D${row}`), 10);
+      if (vol) return { bag, vol };
+    }
+
+    return null;
+  }
+
+  function setImportedBag (bag, vol) {
+    const central = !bag.endsWith(" Peripheral");
+    const product = bag.replace(" Peripheral", "");
+
+    productSel.value = product;
+    nutritSel.value = central ? "centralne" : "obwodowe";
+    renderBagOptions({ preserveDefaults: true });
+
+    const importedOption = Array.from(volSel.options).find(option => Number(option.value) === vol);
+    if (importedOption) {
+      volSel.value = String(vol);
+    }
+  }
+
+  function readImportedAdditives (ws) {
+    const additives = {};
+    const cellValue = cell => parseNum(getCellPlainValue(ws, cell)) || 0;
+
+    for (let i = 1; i <= 17; i++) {
+      additives[`add${i}`] = getCellPlainValue(ws, `D${27 + i}`);
+    }
+
+    additives.add3 = getCellPlainValue(ws, "H30") || getCellPlainValue(ws, "D30");
+    additives.add6 = cellValue("D33") + cellValue("D34");
+    additives.add8 = cellValue("D35") + cellValue("D36");
+    additives.add10 = cellValue("D37") + cellValue("D38");
+
+    return additives;
+  }
+
+  async function importRecipeFile (file) {
+    if (!file) return;
+    if (!window.ExcelJS) {
+      showImportStatus("Nie można wczytać pliku — biblioteka ExcelJS nie jest dostępna.", "error");
+      return;
+    }
+
+    showImportStatus("Wczytywanie recepty...", "info");
+
+    try {
+      const wb = new ExcelJS.Workbook();
+      await wb.xlsx.load(await file.arrayBuffer());
+      const ws = wb.worksheets[0];
+      if (!ws) throw new Error("Brak arkusza w pliku XLSX.");
+
+      $("fullname").value = toInputValue(getCellPlainValue(ws, "C2"));
+      $("pesel").value = toInputValue(getCellPlainValue(ws, "C6"));
+      weightInp.value = toInputValue(getCellPlainValue(ws, "C7"));
+      $("dateFrom").value = toDateInputValue(getCellPlainValue(ws, "C8"));
+      $("dateTo").value = toDateInputValue(getCellPlainValue(ws, "C9"));
+
+      manualAdditives.clear();
+      const importedBag = chooseImportedBag(ws);
+      if (importedBag) {
+        setImportedBag(importedBag.bag, importedBag.vol);
+      }
+
+      const additives = readImportedAdditives(ws);
+      for (const id of additiveInputIds) {
+        setAdditiveValue(id, additives[id]);
+      }
+
+      updateKcal();
+      updateDosage();
+      updateAdditiveRanges();
+      updateElectrolyteSummary();
+
+      const fileName = file.name ? `: ${file.name}` : "";
+      showImportStatus(`Wczytano receptę${fileName}.`, "success");
+    } catch (err) {
+      console.error(err);
+      showImportStatus("Nie udało się wczytać recepty. Wybierz plik XLSX wygenerowany w tym programie.", "error");
+    } finally {
+      importInp.value = "";
+    }
+  }
 
   /* --- zakresy dodatków --- */
   function updateAdditiveRanges () {
@@ -178,7 +322,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   /* --- worki & kcal --- */
-  function renderBagOptions () {
+  function renderBagOptions (options = {}) {
+    const { preserveDefaults = false } = options;
     const bag = currentBag();
 
     volSel.innerHTML = "";
@@ -193,7 +338,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     updateKcal();
     updateDosage();
     updateAdditiveRanges();
-    applyDefaultAdditives();
+    if (!preserveDefaults) applyDefaultAdditives();
     updateElectrolyteSummary();
   }
 
@@ -233,6 +378,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     updateElectrolyteSummary();
   });
   weightInp .addEventListener("input",  () => { updateDosage(); updateAdditiveRanges(); });
+  importInp?.addEventListener("change", event => importRecipeFile(event.target.files[0]));
 
   renderBagOptions();          // początkowe
   updateElectrolyteSummary();

--- a/style.css
+++ b/style.css
@@ -260,3 +260,24 @@ button:hover{background-color:#005fa3;}
   flex:1;
   margin-bottom:0;
 }
+
+/* import poprzedniej recepty */
+.import-recipe .hint,
+.import-status{
+  margin-top:0.5rem;
+  font-size:0.85rem;
+  line-height:1.3;
+}
+
+.import-recipe .hint{
+  color:#555;
+}
+
+.import-status{
+  min-height:1.1rem;
+  font-weight:bold;
+}
+
+.import-status.info{color:#555;}
+.import-status.success{color:#1f7a3a;}
+.import-status.error{color:#b00020;}


### PR DESCRIPTION
### Motivation
- Allow users to load a previously exported XLSX recipe to repopulate form fields and additives for quicker reuse.
- Provide clear UI feedback when an import is in progress or fails so users know the result of their action.

### Description
- Add a file input and status area to the form in `index.html` (`#recipeImport` and `#importStatus`) and related CSS classes for styling.`
- Implement XLSX import handling in `script.js` including `importRecipeFile`, `getCellPlainValue`, `toDateInputValue`, `excelSerialToDateInput`, `setAdditiveValue`, `chooseImportedBag`, `readImportedAdditives`, and `showImportStatus` to parse workbook cells and populate the UI.`
- Preserve user-modified additive inputs by tracking `manualAdditives` and add `preserveDefaults` option to `renderBagOptions` to avoid overwriting manual changes after an import.`
- Wire the import flow to update computed values by calling `updateKcal`, `updateDosage`, `updateAdditiveRanges`, and `updateElectrolyteSummary` after a successful import.`

### Testing
- No automated tests were added for this change and no CI tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218edad888832ea15c38f8be21c4b7)