### PR TITLE
Modularize XLSX exporter, add npm deps, UI validation summary and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.DS_Store
+node_modules/

--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <title>Recepta żywienia parenteralnego</title>
 
-  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <script src="node_modules/jszip/dist/jszip.min.js"></script>
   <!-- ExcelJS (zachowuje formatowanie) -->
-  <script src="https://cdn.jsdelivr.net/npm/exceljs/dist/exceljs.min.js"></script>
+  <script src="node_modules/exceljs/dist/exceljs.min.js"></script>
   <!-- FileSaver do pobierania pliku -->
-  <script src="https://cdn.jsdelivr.net/npm/file-saver@2.0.5/dist/FileSaver.min.js"></script>
+  <script src="node_modules/file-saver/dist/FileSaver.min.js"></script>
 
   <script src="pnCalculator.js" defer></script>
   <script src="script.js" defer></script>
@@ -65,6 +65,7 @@
         </div>
 
       </form>
+      <div id="validationSummary" class="validation-summary" role="alert" aria-live="polite" hidden></div>
       <p class="safety-note">Narzędzie pomocnicze. Ostateczną receptę i zgodność z aktualnymi ChPL oraz stanem klinicznym pacjenta musi zweryfikować uprawniony personel medyczny.</p>
     </div>
     <!-- ▲▲ 1. LEWY KONTENER ▲▲ -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1012 @@
+{
+  "name": "parenteral-nutrition-generator",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "parenteral-nutrition-generator",
+      "version": "1.0.0",
+      "dependencies": {
+        "exceljs": "4.4.0",
+        "file-saver": "2.0.5",
+        "jszip": "3.10.1"
+      }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
     "test": "node --test",
     "check:syntax": "node --check script.js && node --check xlsxGenerator.js && node --check pnCalculator.js"
   },
-  "devDependencies": {}
+  "dependencies": {
+    "exceljs": "4.4.0",
+    "file-saver": "2.0.5",
+    "jszip": "3.10.1"
+  }
 }

--- a/script.js
+++ b/script.js
@@ -21,14 +21,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     bagConfig,
     additiveRangeConfig,
     additiveDefaultConfig,
-    dosageConfig,
-    constants: {
-      DIPEPTIVEN_PER_KG,
-      OMEGAVEN_PER_KG,
-      ADDAMEL_RANGE,
-      VIT_B1_RANGE,
-      VIT_C_RANGE
-    }
+    dosageConfig
   } = cfg;
 
   /* ---------- 2. Cache elementów DOM ---------- */
@@ -45,14 +38,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     calculateAdditiveRanges,
     calculateElectrolyteSummary,
     calculateRequirements,
+    getCurrentBag,
+    ADDITIVE_KCAL_PER_ML,
     validateRecipe
   } = PNCalculator;
 
   const kcalSpan = $("bagCalories");
-  const additiveKcalPerMl = {
-    add6: 0.8,   // Dipeptiven: 80 kcal/100 ml
-    add8: 1.12   // Omegaven: 112 kcal/100 ml
-  };
   const reqMin   = $("reqMin");
   const reqMax   = $("reqMax");
   const reqAbs   = $("reqAbsMax");
@@ -75,9 +66,35 @@ document.addEventListener("DOMContentLoaded", async () => {
   const naReqMax = $("naReqMax");
   const kReqMin  = $("kReqMin");
   const kReqMax  = $("kReqMax");
+  const validationSummary = $("validationSummary");
+
+  function showMessages (messages, title = "Popraw dane przed wygenerowaniem recepty:") {
+    if (!validationSummary) return;
+    validationSummary.hidden = false;
+    validationSummary.innerHTML = "";
+
+    const heading = document.createElement("strong");
+    heading.textContent = title;
+    validationSummary.appendChild(heading);
+
+    const list = document.createElement("ul");
+    messages.forEach(message => {
+      const item = document.createElement("li");
+      item.textContent = message;
+      list.appendChild(item);
+    });
+    validationSummary.appendChild(list);
+    validationSummary.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }
+
+  function clearMessages () {
+    if (!validationSummary) return;
+    validationSummary.hidden = true;
+    validationSummary.innerHTML = "";
+  }
 
   const updateKcal = () => {
-    const additives = Object.fromEntries(Object.keys(additiveKcalPerMl).map(id => [id, $(id)?.value]));
+    const additives = Object.fromEntries(Object.keys(ADDITIVE_KCAL_PER_ML).map(id => [id, $(id)?.value]));
     const total = calculateTotalKcal({
       bagConfig,
       bag: currentBag(),
@@ -100,18 +117,21 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   for (const el of Object.values(additiveInputs)) {
     if (el) {
-      el.addEventListener("input", () => manualAdditives.add(el.id));
+      el.addEventListener("input", () => {
+        manualAdditives.add(el.id);
+        clearMessages();
+      });
     }
   }
 
   ["add10", "add17"].forEach(id => {
     const el = $(id);
-    if (el) el.addEventListener("input", updateElectrolyteSummary);
+    if (el) el.addEventListener("input", () => { clearMessages(); updateElectrolyteSummary(); });
   });
 
   ["add6", "add8"].forEach(id => {
     const el = $(id);
-    if (el) el.addEventListener("input", updateKcal);
+    if (el) el.addEventListener("input", () => { clearMessages(); updateKcal(); });
   });
 
   /* ---------- 3. Inicjalizacja dat ---------- */
@@ -120,10 +140,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   $("dateTo").value   = today;
 
   /* ---------- 4. Funkcje pomocnicze ---------- */
-  const currentBag = () =>
-    nutritSel.value === "obwodowe"
-      ? `${productSel.value} Peripheral`
-      : productSel.value;
+  const currentBag = () => getCurrentBag(productSel.value, nutritSel.value);
 
   /* --- zakresy dodatków --- */
   function updateAdditiveRanges () {
@@ -131,7 +148,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const vol = parseInt(volSel.value, 10);
     const ranges = calculateAdditiveRanges({
       additiveRangeConfig,
-      constants: { DIPEPTIVEN_PER_KG, OMEGAVEN_PER_KG, ADDAMEL_RANGE, VIT_B1_RANGE, VIT_C_RANGE },
+      constants: cfg.constants,
       bag,
       volume: vol,
       weight: weightInp.value
@@ -210,15 +227,20 @@ document.addEventListener("DOMContentLoaded", async () => {
   };
 
   /* --- eventy UI --- */
-  productSel.addEventListener("change", renderBagOptions);
-  nutritSel .addEventListener("change", renderBagOptions);
+  productSel.addEventListener("change", () => { clearMessages(); renderBagOptions(); });
+  nutritSel .addEventListener("change", () => { clearMessages(); renderBagOptions(); });
   volSel    .addEventListener("change", () => {
+    clearMessages();
     updateKcal();
     updateDosage();
     updateAdditiveRanges();
     updateElectrolyteSummary();
   });
-  weightInp .addEventListener("input",  () => { updateDosage(); updateAdditiveRanges(); });
+  weightInp .addEventListener("input",  () => { clearMessages(); updateDosage(); updateAdditiveRanges(); });
+  ["fullname", "pesel", "dateFrom", "dateTo", "sodium", "potassium"].forEach(id => {
+    const el = $(id);
+    if (el) el.addEventListener("input", clearMessages);
+  });
 
   renderBagOptions();          // początkowe
   updateElectrolyteSummary();
@@ -279,19 +301,26 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
 
     if (!validation.valid) {
-      alert(`Popraw dane przed wygenerowaniem recepty:\n\n${validation.errors.join("\n")}`);
+      showMessages(validation.errors);
       return;
     }
+
+    clearMessages();
 
     /* flaga centralne/obwodowe */
     const central = nutritSel.value === "centralne";
 
     /* wywołaj zewnętrzny generator */
-    await generateRecipeXlsx({
-      data,
-      currentBag: currentBag(),
-      central,
-      cfg        // przekazujemy pełny konfig, bo tam są wszystkie stałe
-    });
+    try {
+      await generateRecipeXlsx({
+        data,
+        currentBag: currentBag(),
+        central,
+        cfg        // przekazujemy pełny konfig, bo tam są wszystkie stałe
+      });
+    } catch (err) {
+      console.error(err);
+      showMessages([err.message || "Nieznany błąd eksportu XLSX."], "Nie udało się wygenerować pliku XLSX:");
+    }
   });
 });

--- a/style.css
+++ b/style.css
@@ -271,3 +271,22 @@ button:hover{background-color:#005fa3;}
   border-radius:4px;
   padding:0.75rem;
 }
+
+.validation-summary{
+  margin-top:1rem;
+  padding:0.75rem;
+  color:#7a1d1d;
+  background:#fff1f1;
+  border:1px solid #f0a3a3;
+  border-radius:4px;
+  font-size:0.9rem;
+  line-height:1.35;
+}
+
+.validation-summary ul{
+  margin:0.5rem 0 0 1.25rem;
+}
+
+.validation-summary li + li{
+  margin-top:0.25rem;
+}

--- a/test/xlsxGenerator.test.js
+++ b/test/xlsxGenerator.test.js
@@ -1,0 +1,112 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const ExcelJS = require('exceljs');
+const JSZip = require('jszip');
+
+const generator = require('../xlsxGenerator.js');
+const cfg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'config.json'), 'utf8'));
+
+function createWorkbook () {
+  const workbook = new ExcelJS.Workbook();
+  workbook.addWorksheet('Recepta');
+  return workbook;
+}
+
+const sampleData = {
+  name: 'Anna / Testowa',
+  pesel: '44051401458',
+  weight: 70,
+  dateFrom: '2026-06-06',
+  dateTo: '2026-06-06',
+  bagVol: 1206,
+  additives: Array.from({ length: 17 }, (_, index) => index + 1)
+};
+
+test('fillRecipeWorksheet writes patient, bag, route and additive cells', () => {
+  const workbook = createWorkbook();
+  const worksheet = generator.fillRecipeWorksheet({
+    workbook,
+    data: sampleData,
+    currentBag: 'SmofKabiven Peripheral',
+    central: false,
+    cfg
+  });
+
+  assert.equal(worksheet.getCell('C2').value, sampleData.name);
+  assert.equal(worksheet.getCell('C6').value, sampleData.pesel);
+  assert.equal(worksheet.getCell('C7').value, sampleData.weight);
+  assert.equal(worksheet.getCell('C11').value, 'Obwodowa X');
+  assert.equal(worksheet.getCell('C12').value, 'Centralna');
+  assert.equal(worksheet.getCell('C26').value, 800);
+  assert.equal(worksheet.getCell('D26').value, 1206);
+  assert.equal(worksheet.getCell('D30').value, '');
+  assert.equal(worksheet.getCell('H30').value, 3);
+  assert.equal(worksheet.pageSetup.orientation, 'portrait');
+  assert.equal(worksheet.pageSetup.fitToPage, true);
+});
+
+test('buildRecipeFileName sanitizes patient name and includes bag and route', () => {
+  assert.equal(
+    generator.buildRecipeFileName({
+      patientName: 'Anna / Testowa:*?',
+      currentBag: 'SmofKabiven Peripheral',
+      central: false
+    }),
+    'Anna Testowa SmofKabiven obwodowe.xlsx'
+  );
+});
+
+test('applyPrintArea replaces previous XLSX print area definition', async () => {
+  const workbook = createWorkbook();
+  const worksheet = workbook.worksheets[0];
+  workbook.definedNames.add(`${worksheet.name}!$A$1:$B$2`, '_xlnm.Print_Area');
+  const buffer = await workbook.xlsx.writeBuffer();
+
+  const finalBlob = await generator.applyPrintArea({
+    buffer,
+    worksheetName: worksheet.name,
+    printRange: '$A$1:$M$56',
+    JSZipImpl: JSZip
+  });
+  const finalBuffer = Buffer.from(await finalBlob.arrayBuffer());
+  const zip = await JSZip.loadAsync(finalBuffer);
+  const workbookXml = await zip.file('xl/workbook.xml').async('text');
+
+  assert.match(workbookXml, /name="_xlnm\.Print_Area"/);
+  assert.match(workbookXml, /'Recepta'!\$A\$1:\$M\$56/);
+  assert.doesNotMatch(workbookXml, /\$A\$1:\$B\$2/);
+});
+
+test('buildRecipeXlsxBlob loads template, fills workbook and returns export metadata', async () => {
+  const workbook = createWorkbook();
+  const templateBuffer = await workbook.xlsx.writeBuffer();
+  const calls = [];
+
+  const result = await generator.buildRecipeXlsxBlob({
+    data: sampleData,
+    currentBag: 'SmofKabiven Peripheral',
+    central: false,
+    cfg,
+    dependencies: {
+      ExcelJS,
+      JSZip,
+      fetch: async url => {
+        calls.push(url);
+        return {
+          ok: true,
+          arrayBuffer: async () => templateBuffer
+        };
+      }
+    }
+  });
+
+  assert.deepEqual(calls, [cfg.constants.TEMPLATE_FILE]);
+  assert.equal(result.fileName, 'Anna Testowa SmofKabiven obwodowe.xlsx');
+
+  const exportedBuffer = Buffer.from(await result.blob.arrayBuffer());
+  const zip = await JSZip.loadAsync(exportedBuffer);
+  const workbookXml = await zip.file('xl/workbook.xml').async('text');
+  assert.match(workbookXml, /'Recepta'!\$A\$1:\$M\$56/);
+});

--- a/xlsxGenerator.js
+++ b/xlsxGenerator.js
@@ -1,100 +1,182 @@
 /* xlsxGenerator.js
- * Eksport recepty do pliku XLSX na podstawie danych z formularza
- * Wymaga: ExcelJS, JSZip, FileSaver (już dodane w <head>)
+ * Eksport recepty do pliku XLSX na podstawie danych z formularza.
+ * Wymaga w przeglądarce: ExcelJS, JSZip, FileSaver.
  */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  root.PNXlsxGenerator = api;
+  root.generateRecipeXlsx = api.generateRecipeXlsx;
+})(typeof globalThis !== "undefined" ? globalThis : window, function () {
+  const BAG_ROW_MAP = {
+    SmofKabiven: 24,
+    "SmofKabiven Peripheral": 26,
+    Kabiven: 23,
+    "Kabiven Peripheral": 25
+  };
 
-async function generateRecipeXlsx ({ data, currentBag, central, cfg }) {
-    const {
-      bagConfig,
-      constants: { TEMPLATE_FILE, PRINT_RANGE }
-    } = cfg;
-  
-    try {
-      /* 1. Pobierz szablon XLSX */
-      const resp = await fetch(TEMPLATE_FILE);
-      if (!resp.ok) {
-        alert("Błąd pobierania szablonu");
-        return;
-      }
-  
-      /* 2. Wczytaj workbook */
-      const wb = new ExcelJS.Workbook();
-      await wb.xlsx.load(await resp.arrayBuffer());
-      const ws = wb.worksheets[0];
-  
-      /* 3. Wypełnij dane pacjenta */
-      ws.getCell("C2").value = data.name;
-      ws.getCell("C6").value = data.pesel;
-      ws.getCell("C7").value = data.weight;
-      ws.getCell("C8").value = data.dateFrom;
-      ws.getCell("C9").value = data.dateTo;
-  
-      ws.getCell("C11").value = central ? "Obwodowa"    : "Obwodowa X";
-      ws.getCell("C12").value = central ? "Centralna X" : "Centralna";
-  
-      /* 4. Worek – kcal + ml */
-      const rowMap = {
-        "SmofKabiven":24,"SmofKabiven Peripheral":26,
-        "Kabiven":23,"Kabiven Peripheral":25
-      };
-      [23,24,25,26].forEach(r => {
-        ws.getCell(`C${r}`).value = "";
-        ws.getCell(`D${r}`).value = "";
-      });
-  
-      const tr = rowMap[currentBag];
-      if (tr) {
-        const info = (bagConfig[currentBag] || []).find(b => b.vol === data.bagVol);
-        ws.getCell(`C${tr}`).value = info ? info.kcal : "";
-        ws.getCell(`D${tr}`).value = data.bagVol;
-      }
-  
-      /* 5. Dodatki – kol. D (28-44) */
-      data.additives.forEach((v, i) => ws.getCell(28 + i, 4).value = v);
-      ws.getCell("D30").value = "";                    // Soluvit do H30
-      ws.getCell("H30").value = data.additives[2] || "";
-  
-      /* 6. Ustawienia strony */
-      ws.pageSetup.orientation = 'portrait';
-      ws.pageSetup.fitToPage   = true;
-      ws.pageSetup.fitToWidth  = 1;
-      ws.pageSetup.fitToHeight = 1;
-  
-      /* 7. Zapis do bufora */
-      const buffer = await wb.xlsx.writeBuffer();
-  
-      /* 8. Modyfikacja workbook.xml (Print_Area) */
-      const zip = await JSZip.loadAsync(buffer);
-      const wbXmlPath = "xl/workbook.xml";
-      const wbXmlText = await zip.file(wbXmlPath).async("text");
-  
-      const clearedXml = wbXmlText.replace(
-        /<definedName[^>]*name="_xlnm\.Print_Area"[\s\S]*?<\/definedName>/g,
-        ""
-      );
-  
-      const safeSheetName = ws.name.replace(/'/g, "''");
-      const printAreaNode =
-        `<definedName function="false" hidden="false" localSheetId="0" ` +
-        `name="_xlnm.Print_Area" vbProcedure="false">` +
-        `'${safeSheetName}'!${PRINT_RANGE}</definedName>`;
-  
-      const finalXml = clearedXml.includes("<definedNames>")
-        ? clearedXml.replace("</definedNames>", `${printAreaNode}</definedNames>`)
-        : clearedXml.replace("</workbook>", `<definedNames>${printAreaNode}</definedNames></workbook>`);
-  
-      zip.file(wbXmlPath, finalXml);
-  
-      /* 9. Eksport pliku */
-      const finalBlob = await zip.generateAsync({ type: "blob" });
-      const bagLabel   = currentBag.replace(" Peripheral", "");
-      const routeLabel = central ? "centralne" : "obwodowe";
-      const safePatient = (data.name || "pacjent").replace(/[\\/:*?"<>|]+/g, " ").replace(/\s+/g, " ").trim();
-      const fileName   = `${safePatient} ${bagLabel} ${routeLabel}.xlsx`;
-      saveAs(finalBlob, fileName);
-    } catch (err) {
-      console.error(err);
-      alert("Wystąpił błąd podczas generowania pliku XLSX.");
-    }
+  const PATIENT_CELL_MAP = {
+    name: "C2",
+    pesel: "C6",
+    weight: "C7",
+    dateFrom: "C8",
+    dateTo: "C9"
+  };
+
+  function getDependency (explicitDependency, globalName) {
+    if (explicitDependency) return explicitDependency;
+    if (typeof globalThis !== "undefined" && globalThis[globalName]) return globalThis[globalName];
+    throw new Error(`Brak wymaganej biblioteki: ${globalName}.`);
   }
-  
+
+  function assertRecipeInputs ({ data, currentBag, cfg }) {
+    if (!data || typeof data !== "object") throw new Error("Brak danych recepty do eksportu.");
+    if (!currentBag) throw new Error("Nie wybrano typu worka do eksportu.");
+    if (!cfg?.bagConfig?.[currentBag]) throw new Error(`Brak konfiguracji worka: ${currentBag}.`);
+    if (!cfg?.constants?.TEMPLATE_FILE) throw new Error("Brak ścieżki do szablonu XLSX w konfiguracji.");
+    if (!cfg?.constants?.PRINT_RANGE) throw new Error("Brak zakresu wydruku w konfiguracji.");
+  }
+
+  function getFirstWorksheet (workbook) {
+    const worksheet = workbook?.worksheets?.[0];
+    if (!worksheet) throw new Error("Szablon XLSX nie zawiera arkusza roboczego.");
+    return worksheet;
+  }
+
+  function fillRecipeWorksheet ({ workbook, data, currentBag, central, cfg }) {
+    assertRecipeInputs({ data, currentBag, cfg });
+    const ws = getFirstWorksheet(workbook);
+
+    ws.getCell(PATIENT_CELL_MAP.name).value = data.name;
+    ws.getCell(PATIENT_CELL_MAP.pesel).value = data.pesel;
+    ws.getCell(PATIENT_CELL_MAP.weight).value = data.weight;
+    ws.getCell(PATIENT_CELL_MAP.dateFrom).value = data.dateFrom;
+    ws.getCell(PATIENT_CELL_MAP.dateTo).value = data.dateTo;
+
+    ws.getCell("C11").value = central ? "Obwodowa" : "Obwodowa X";
+    ws.getCell("C12").value = central ? "Centralna X" : "Centralna";
+
+    Object.values(BAG_ROW_MAP).forEach(row => {
+      ws.getCell(`C${row}`).value = "";
+      ws.getCell(`D${row}`).value = "";
+    });
+
+    const targetRow = BAG_ROW_MAP[currentBag];
+    if (!targetRow) throw new Error(`Nieobsługiwany typ worka: ${currentBag}.`);
+
+    const bagInfo = (cfg.bagConfig[currentBag] || []).find(bag => Number(bag.vol) === Number(data.bagVol));
+    if (!bagInfo) throw new Error(`Brak objętości ${data.bagVol} ml dla worka ${currentBag}.`);
+    ws.getCell(`C${targetRow}`).value = bagInfo.kcal;
+    ws.getCell(`D${targetRow}`).value = data.bagVol;
+
+    (data.additives || []).forEach((value, index) => {
+      ws.getCell(28 + index, 4).value = value;
+    });
+    ws.getCell("D30").value = "";
+    ws.getCell("H30").value = data.additives?.[2] || "";
+
+    ws.pageSetup.orientation = "portrait";
+    ws.pageSetup.fitToPage = true;
+    ws.pageSetup.fitToWidth = 1;
+    ws.pageSetup.fitToHeight = 1;
+
+    return ws;
+  }
+
+  async function fetchTemplateBuffer ({ fetchFn, templateFile }) {
+    if (typeof fetchFn !== "function") throw new Error("Brak funkcji fetch do pobrania szablonu XLSX.");
+    const response = await fetchFn(templateFile);
+    if (!response?.ok) {
+      const status = response?.status ? ` HTTP ${response.status}` : "";
+      throw new Error(`Nie udało się pobrać szablonu XLSX:${status}.`);
+    }
+    if (typeof response.arrayBuffer !== "function") {
+      throw new Error("Odpowiedź szablonu XLSX nie zawiera danych binarnych.");
+    }
+    return response.arrayBuffer();
+  }
+
+  function buildPrintAreaNode ({ worksheetName, printRange }) {
+    const safeSheetName = worksheetName.replace(/'/g, "''");
+    return `<definedName function="false" hidden="false" localSheetId="0" name="_xlnm.Print_Area" vbProcedure="false">'${safeSheetName}'!${printRange}</definedName>`;
+  }
+
+  async function applyPrintArea ({ buffer, worksheetName, printRange, JSZipImpl }) {
+    const zip = await JSZipImpl.loadAsync(buffer);
+    const workbookXmlPath = "xl/workbook.xml";
+    const workbookXmlFile = zip.file(workbookXmlPath);
+    if (!workbookXmlFile) throw new Error("Szablon XLSX nie zawiera xl/workbook.xml.");
+
+    const workbookXmlText = await workbookXmlFile.async("text");
+    const clearedXml = workbookXmlText.replace(
+      /<definedName[^>]*name="_xlnm\.Print_Area"[\s\S]*?<\/definedName>/g,
+      ""
+    );
+    const printAreaNode = buildPrintAreaNode({ worksheetName, printRange });
+
+    const finalXml = clearedXml.includes("<definedNames>")
+      ? clearedXml.replace("</definedNames>", `${printAreaNode}</definedNames>`)
+      : clearedXml.replace("</workbook>", `<definedNames>${printAreaNode}</definedNames></workbook>`);
+
+    zip.file(workbookXmlPath, finalXml);
+    return zip.generateAsync({ type: "blob" });
+  }
+
+  function buildRecipeFileName ({ patientName, currentBag, central }) {
+    const bagLabel = currentBag.replace(" Peripheral", "");
+    const routeLabel = central ? "centralne" : "obwodowe";
+    const safePatient = (patientName || "pacjent")
+      .replace(/[\\/:*?"<>|]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim() || "pacjent";
+    return `${safePatient} ${bagLabel} ${routeLabel}.xlsx`;
+  }
+
+  async function buildRecipeXlsxBlob ({ data, currentBag, central, cfg, dependencies = {} }) {
+    assertRecipeInputs({ data, currentBag, cfg });
+    const ExcelJSImpl = getDependency(dependencies.ExcelJS, "ExcelJS");
+    const JSZipImpl = getDependency(dependencies.JSZip, "JSZip");
+    const fetchFn = dependencies.fetch || (typeof fetch !== "undefined" ? fetch : null);
+
+    const templateBuffer = await fetchTemplateBuffer({
+      fetchFn,
+      templateFile: cfg.constants.TEMPLATE_FILE
+    });
+
+    const workbook = new ExcelJSImpl.Workbook();
+    await workbook.xlsx.load(templateBuffer);
+    const worksheet = fillRecipeWorksheet({ workbook, data, currentBag, central, cfg });
+    const workbookBuffer = await workbook.xlsx.writeBuffer();
+    const blob = await applyPrintArea({
+      buffer: workbookBuffer,
+      worksheetName: worksheet.name,
+      printRange: cfg.constants.PRINT_RANGE,
+      JSZipImpl
+    });
+
+    return {
+      blob,
+      fileName: buildRecipeFileName({ patientName: data.name, currentBag, central })
+    };
+  }
+
+  async function generateRecipeXlsx ({ data, currentBag, central, cfg, dependencies = {} }) {
+    const saveAsFn = dependencies.saveAs || (typeof saveAs !== "undefined" ? saveAs : null);
+    if (typeof saveAsFn !== "function") throw new Error("Brak funkcji saveAs do zapisania pliku XLSX.");
+    const { blob, fileName } = await buildRecipeXlsxBlob({ data, currentBag, central, cfg, dependencies });
+    saveAsFn(blob, fileName);
+    return { blob, fileName };
+  }
+
+  return {
+    BAG_ROW_MAP,
+    PATIENT_CELL_MAP,
+    fillRecipeWorksheet,
+    fetchTemplateBuffer,
+    buildPrintAreaNode,
+    applyPrintArea,
+    buildRecipeFileName,
+    buildRecipeXlsxBlob,
+    generateRecipeXlsx
+  };
+});


### PR DESCRIPTION
### Motivation
- Replace CDN scripts with npm-managed packages for reproducible local builds and testing (`exceljs`, `jszip`, `file-saver`).
- Refactor the XLSX export logic into a testable module so generation can be exercised under Node and in-browser with better error handling. 
- Improve user feedback by showing validation/errors inline in the UI instead of only via `alert`.

### Description
- Added package dependencies in `package.json` and a generated `package-lock.json`, and updated `.gitignore` to exclude `node_modules/`.
- Updated `index.html` to load libraries from `node_modules/` and added a DOM node for the validation summary (`#validationSummary`).
- Reworked `script.js` to add `showMessages`/`clearMessages`, wire validation into the UI, clear messages on input changes, use `getCurrentBag`/constants from `PNCalculator`, and wrap the call to `generateRecipeXlsx` in `try/catch` to present export errors in the validation summary.
- Refactored `xlsxGenerator.js` into a UMD-style module that exports functions (`fillRecipeWorksheet`, `applyPrintArea`, `buildRecipeXlsxBlob`, `generateRecipeXlsx`) with robust input validation, dependency injection for `ExcelJS`/`JSZip`/`fetch`/`saveAs`, and safer print-area handling.
- Added styles for the inline validation summary in `style.css` and introduced unit tests in `test/xlsxGenerator.test.js` that exercise worksheet filling, filename building, print-area application, and full blob creation using injected dependencies.

### Testing
- Added unit tests in `test/xlsxGenerator.test.js` and ran the test suite via `node --test` (the repository `test` runner for Node); the new tests executed against the refactored module and passed.
- The XLSX generator tests specifically exercised `fillRecipeWorksheet`, `buildRecipeFileName`, `applyPrintArea`, and `buildRecipeXlsxBlob` using `ExcelJS` and `JSZip` and returned the expected results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a235a34c4d0832e8c70d90e1c685bcc)