### PR TITLE
Fix XLSX date field mapping (C8/C9)

### DIFF
--- a/script.js
+++ b/script.js
@@ -384,8 +384,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       $("fullname").value = toInputValue(getCellPlainValue(ws, "C2"));
       $("pesel").value = toInputValue(getCellPlainValue(ws, "C6"));
       weightInp.value = toInputValue(getCellPlainValue(ws, "C7"));
-      $("dateFrom").value = toDateInputValue(getCellPlainValue(ws, "C8"));
-      $("dateTo").value = toDateInputValue(getCellPlainValue(ws, "C9"));
+      // Template: C8 = Data podania, C9 = Data wystawienia.
+      $("dateTo").value = toDateInputValue(getCellPlainValue(ws, "C8"));
+      $("dateFrom").value = toDateInputValue(getCellPlainValue(ws, "C9"));
 
       manualAdditives.clear();
       const importedBag = chooseImportedBag(ws);

--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -312,6 +312,12 @@ test('validation warnings refresh while editing recipe fields', () => {
   assert.match(scriptJs, /weightInp \.addEventListener\("input"[\s\S]*refreshValidationWarnings\(\);/);
 });
 
+test('recipe import maps template date cells to the correct form fields', () => {
+  assert.match(scriptJs, /C8 = Data podania, C9 = Data wystawienia/);
+  assert.match(scriptJs, /\$\("dateTo"\)\.value = toDateInputValue\(getCellPlainValue\(ws, "C8"\)\);/);
+  assert.match(scriptJs, /\$\("dateFrom"\)\.value = toDateInputValue\(getCellPlainValue\(ws, "C9"\)\);/);
+});
+
 test('application does not persist form data in browser storage', () => {
   assert.doesNotMatch(scriptJs, /localStorage/);
   assert.doesNotMatch(scriptJs, /sessionStorage/);
@@ -380,6 +386,8 @@ test('generateRecipeXlsx fills template cells and print area', async () => {
   assert.equal(ws.getCell('C2').value, 'Jan Testowy');
   assert.equal(ws.getCell('C6').value, '44051401458');
   assert.equal(ws.getCell('C7').value, 70);
+  assert.equal(ws.getCell('C8').value, '2026-06-06');
+  assert.equal(ws.getCell('C9').value, '2026-06-05');
   assert.equal(ws.getCell('C11').value, 'Obwodowa X');
   assert.equal(ws.getCell('C12').value, 'Centralna');
   assert.equal(ws.getCell('C26').value, 800);

--- a/xlsxGenerator.js
+++ b/xlsxGenerator.js
@@ -44,8 +44,9 @@ async function generateRecipeXlsx ({
       ws.getCell("C2").value = data.name;
       ws.getCell("C6").value = data.pesel;
       ws.getCell("C7").value = data.weight;
-      ws.getCell("C8").value = data.dateFrom;
-      ws.getCell("C9").value = data.dateTo;
+      // Template: C8 = Data podania, C9 = Data wystawienia.
+      ws.getCell("C8").value = data.dateTo;
+      ws.getCell("C9").value = data.dateFrom;
   
       ws.getCell("C11").value = central ? "Obwodowa"    : "Obwodowa X";
       ws.getCell("C12").value = central ? "Centralna X" : "Centralna";


### PR DESCRIPTION
### Motivation

- The XLSX template uses `C8` for "Data podania" (administration date) and `C9` for "Data wystawienia" (issue date), but the code read/write those cells reversed, causing incorrect imports/exports.

### Description

- Swap the date mapping when generating workbooks so `ws.getCell("C8")` receives `data.dateTo` and `ws.getCell("C9")` receives `data.dateFrom` in `xlsxGenerator.js`.
- Update XLSX import in `script.js` so `C8` populates the form `dateTo` and `C9` populates `dateFrom` with a clarifying comment about the template mapping.
- Add a regression test in `test/pnCalculator.test.js` asserting the import mapping and updated expectations for generated workbook cell values (`C8`/`C9`).

### Testing

- Ran `npm test` which executed the full test suite and all tests passed (`29` passed, `0` failed).  
- Ran `npm run check:syntax` to verify syntax; it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a255b09f778832e892141024f7268d3)