### PR TITLE
Force Excel recalculation for generated XLSX files

### DIFF
--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -396,9 +396,14 @@ test('generateRecipeXlsx fills template cells and print area', async () => {
   assert.equal(ws.getCell('H30').value, 1);
   assert.equal(ws.getCell('D33').value, 50);
   assert.equal(ws.getCell('D35').value, 25);
+  assert.deepEqual(ws.getCell('B66').value, { formula: 'SUM(D23:D44)', result: 1321 });
+  assert.deepEqual(ws.getCell('B52').value, { formula: 'CONCATENATE(B66,C66)', result: '1321ml' });
 
   const zip = await JSZip.loadAsync(result.buffer);
   const workbookXml = await zip.file('xl/workbook.xml').async('text');
   assert.match(workbookXml, /name="_xlnm\.Print_Area"/);
   assert.match(workbookXml, /\$A\$1:\$M\$56/);
+  assert.match(workbookXml, /<calcPr[^>]*calcMode="auto"/);
+  assert.match(workbookXml, /<calcPr[^>]*fullCalcOnLoad="1"/);
+  assert.match(workbookXml, /<calcPr[^>]*forceFullCalc="1"/);
 });

--- a/xlsxGenerator.js
+++ b/xlsxGenerator.js
@@ -3,6 +3,64 @@
  * Wymaga: ExcelJS, JSZip, FileSaver (już dodane w <head>)
  */
 
+function numericCellValue (cell) {
+  const value = cell.value;
+  if (typeof value === "number") return value;
+  if (value && typeof value === "object" && typeof value.result === "number") return value.result;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function refreshVolumeFormulaCache (ws) {
+  const totalVolume = Array.from({ length: 22 }, (_, i) => 23 + i)
+    .reduce((sum, row) => sum + numericCellValue(ws.getCell(`D${row}`)), 0);
+  const volumeUnit = ws.getCell("C66").value || "";
+
+  ws.getCell("B66").value = {
+    formula: "SUM(D23:D44)",
+    result: totalVolume
+  };
+  ws.getCell("B52").value = {
+    formula: "CONCATENATE(B66,C66)",
+    result: `${totalVolume}${volumeUnit}`
+  };
+}
+
+function setXmlAttribute (node, name, value) {
+  const attributePattern = new RegExp(`\\s${name}="[^"]*"`, "g");
+  const cleanedNode = node.replace(attributePattern, "");
+  const selfClosing = /\/>$/.test(cleanedNode);
+  const tagBody = cleanedNode.replace(/\s*\/?>$/, "");
+  return `${tagBody} ${name}="${value}"${selfClosing ? "/>" : ">"}`;
+}
+
+function forceWorkbookRecalculation (workbookXml) {
+  const recalcAttributes = [
+    ["calcMode", "auto"],
+    ["fullCalcOnLoad", "1"],
+    ["forceFullCalc", "1"]
+  ];
+  const calcPrPattern = /<calcPr\b[^>]*(?:\/>|>[\s\S]*?<\/calcPr>)/;
+
+  if (calcPrPattern.test(workbookXml)) {
+    return workbookXml.replace(calcPrPattern, node => {
+      const openTagMatch = node.match(/^<calcPr\b[^>]*>/);
+      if (!openTagMatch) return node;
+
+      const openTag = recalcAttributes.reduce(
+        (updated, [name, value]) => setXmlAttribute(updated, name, value),
+        openTagMatch[0]
+      );
+      return `${openTag}${node.slice(openTagMatch[0].length)}`;
+    });
+  }
+
+  const calcPrNode = '<calcPr calcMode="auto" fullCalcOnLoad="1" forceFullCalc="1"/>';
+  return workbookXml.includes("<extLst>")
+    ? workbookXml.replace("<extLst>", `${calcPrNode}<extLst>`)
+    : workbookXml.replace("</workbook>", `${calcPrNode}</workbook>`);
+}
+
 async function generateRecipeXlsx ({
     data,
     currentBag,
@@ -72,17 +130,20 @@ async function generateRecipeXlsx ({
       data.additives.forEach((v, i) => ws.getCell(28 + i, 4).value = v);
       ws.getCell("D30").value = "";                    // Soluvit do H30
       ws.getCell("H30").value = data.additives[2] || "";
+
+      /* 6. Odśwież cache formuł zależnych od objętości. */
+      refreshVolumeFormulaCache(ws);
   
-      /* 6. Ustawienia strony */
+      /* 7. Ustawienia strony */
       ws.pageSetup.orientation = 'portrait';
       ws.pageSetup.fitToPage   = true;
       ws.pageSetup.fitToWidth  = 1;
       ws.pageSetup.fitToHeight = 1;
   
-      /* 7. Zapis do bufora */
+      /* 8. Zapis do bufora */
       const buffer = await wb.xlsx.writeBuffer();
   
-      /* 8. Modyfikacja workbook.xml (Print_Area) */
+      /* 9. Modyfikacja workbook.xml (Print_Area + przeliczenie formuł w Excelu) */
       const zip = await Zip.loadAsync(buffer);
       const wbXmlPath = "xl/workbook.xml";
       const wbXmlText = await zip.file(wbXmlPath).async("text");
@@ -98,13 +159,14 @@ async function generateRecipeXlsx ({
         `name="_xlnm.Print_Area" vbProcedure="false">` +
         `'${safeSheetName}'!${PRINT_RANGE}</definedName>`;
   
-      const finalXml = clearedXml.includes("<definedNames>")
+      const printAreaXml = clearedXml.includes("<definedNames>")
         ? clearedXml.replace("</definedNames>", `${printAreaNode}</definedNames>`)
         : clearedXml.replace("</workbook>", `<definedNames>${printAreaNode}</definedNames></workbook>`);
+      const finalXml = forceWorkbookRecalculation(printAreaXml);
   
       zip.file(wbXmlPath, finalXml);
   
-      /* 9. Eksport pliku */
+      /* 10. Eksport pliku */
       const bagLabel   = currentBag.replace(" Peripheral", "");
       const routeLabel = central ? "centralne" : "obwodowe";
       const safePatient = (data.name || "pacjent").replace(/[\\/:*?"<>|]+/g, " ").replace(/\s+/g, " ").trim();
@@ -131,6 +193,6 @@ async function generateRecipeXlsx ({
   }
 
 if (typeof module === "object" && module.exports) {
-  module.exports = { generateRecipeXlsx };
+  module.exports = { generateRecipeXlsx, forceWorkbookRecalculation, refreshVolumeFormulaCache };
 }
   


### PR DESCRIPTION
### Motivation
- Excel files generated from the template showed stale values after opening (column `B66` SUM and dependent `B52` not updated), so the exporter must provide correct cached results and request Excel to recalculate on open.

### Description
- Add `numericCellValue` and `refreshVolumeFormulaCache` to compute and write cached results for `B66` (`SUM(D23:D44)`) and `B52` (`CONCATENATE(B66,C66)`) into the workbook before saving.
- Add `setXmlAttribute` and `forceWorkbookRecalculation` helpers to patch `xl/workbook.xml` and set `calcPr` attributes `calcMode="auto"`, `fullCalcOnLoad="1"` and `forceFullCalc="1"` so Excel will perform a full recalculation on open.
- Wire `refreshVolumeFormulaCache` into the generation flow so cached values are set after filling additive/volume inputs, and apply `forceWorkbookRecalculation` when writing back `workbook.xml` into the ZIP.
- Update exports so `forceWorkbookRecalculation` and `refreshVolumeFormulaCache` are accessible for tests, and extend `test/pnCalculator.test.js` to assert cached cell values and the new `calcPr` flags.

### Testing
- Ran unit tests with `npm test` and syntax checks with `npm run check:syntax`, both succeeded; test suite shows `29` tests and all passed.
- Verified generated XLSX by loading buffer with `ExcelJS` and `JSZip` in tests, asserting `ws.getCell('B66').value` and `ws.getCell('B52').value` contain the expected `{ formula, result }` cached objects and that `xl/workbook.xml` contains the `calcPr` attributes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25632983bc832eae46c4fd22106ef0)