### PR TITLE
Compact patient electrolyte fields

### DIFF
--- a/style.css
+++ b/style.css
@@ -137,27 +137,31 @@ body{
   display:flex;
   align-items:center;
   flex-wrap:wrap;
-  gap:0.5rem;
+  column-gap:0.35rem;
+  row-gap:0.35rem;
 }
 .form-group.inline label{
   margin-bottom:0;
   white-space:nowrap;
-  width:6rem;
-  flex:0 0 6rem;
+  width:5.15rem;
+  flex:0 0 5.15rem;
 }
 .form-group.inline input{
-  width:5rem;
-  flex:0 0 auto;
+  width:3.25rem;
+  flex:0 0 3.25rem;
+  padding:0.45rem;
+  font-size:0.95rem;
 }
 
 #weight,
 #sodium,
 #potassium {
-  width:4rem;
+  width:3.25rem;
 }
 .form-group.inline .unit{
-  margin-left:0.25rem;
+  margin-left:0;
   white-space:nowrap;
+  font-size:0.9rem;
 }
 
 /* Flexbox wrapper dla kontenerów */

--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -10,6 +10,7 @@ const { generateRecipeXlsx } = require('../xlsxGenerator.js');
 const cfg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'config.json'), 'utf8'));
 const indexHtml = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
 const scriptJs = fs.readFileSync(path.join(__dirname, '..', 'script.js'), 'utf8');
+const styleCss = fs.readFileSync(path.join(__dirname, '..', 'style.css'), 'utf8');
 
 test('parseNumber accepts Polish decimal comma and rejects malformed values', () => {
   assert.equal(calc.parseNumber('3,5'), 3.5);
@@ -281,6 +282,14 @@ test('NaCl and KCl rows are visible in the additive table', () => {
 test('Vit B1 and Vit C rows are hidden in the additive table', () => {
   assert.match(indexHtml, /<tr[^>]*display\s*:\s*none[^>]*>[\s\S]*id="add15"/);
   assert.match(indexHtml, /<tr[^>]*display\s*:\s*none[^>]*>[\s\S]*id="add16"/);
+});
+
+
+test('patient electrolyte inline fields use compact sizing', () => {
+  assert.match(styleCss, /\.form-group\.inline label\{[\s\S]*flex:0 0 5\.15rem;/);
+  assert.match(styleCss, /\.form-group\.inline input\{[\s\S]*flex:0 0 3\.25rem;/);
+  assert.match(styleCss, /#weight,[\s\S]*#sodium,[\s\S]*#potassium \{[\s\S]*width:3\.25rem;/);
+  assert.match(styleCss, /\.form-group\.inline \.unit\{[\s\S]*font-size:0\.9rem;/);
 });
 
 test('application starts with default patient weight of 65 kg', () => {


### PR DESCRIPTION
### Motivation
- Reduce label/input widths and gaps for the inline patient fields so "Masa ciała", "Sód" and "Potas" reliably fit on a single row in the patient form.

### Description
- Adjusted `style.css` to use smaller label and input widths, reduced column/row gaps and tightened unit font/padding, and added a small regression test in `test/pnCalculator.test.js` (and its import of `style.css`) that asserts the compact CSS rules.

### Testing
- Ran `npm test` (all tests passed, 30/30) and `npm run check:syntax` (no syntax errors), and attempted a Playwright screenshot with `npx --yes playwright screenshot` which was blocked because the browser binaries could not be installed (`npx --yes playwright install chromium` failed with CDN `403 Domain forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a256be7eeec832eb17a1c652e3a235f)