### PR TITLE
Add application footer and automatic version date fetched from GitHub

### DIFF
--- a/config.json
+++ b/config.json
@@ -158,6 +158,12 @@
       "Kabiven Peripheral":     { "min": 27, "max": 40, "maxDaily": 40 }
     },
 
+    "versionConfig": {
+      "githubRepository": "macpiek/parenteral_nutrition_generator",
+      "branch": "main",
+      "fallbackDate": "2026-06-07"
+    },
+
     "constants": {
       "DIPEPTIVEN_PER_KG": 2.5,
       "OMEGAVEN_PER_KG":   2.0,

--- a/index.html
+++ b/index.html
@@ -284,5 +284,9 @@
     </div><!-- /mix-params -->
     <!-- ▲▲ 3. PARAMETRY MIESZANINY ▲▲ -->
   </div><!-- /wrapper -->
+  <footer class="app-footer" aria-label="Informacje o aplikacji">
+    <div>Autor: Maciej Piekarski</div>
+    <div>Wersja: <span id="appVersion">ładowanie...</span></div>
+  </footer>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -54,6 +54,42 @@ document.addEventListener("DOMContentLoaded", async () => {
     generationMessage.textContent = "";
   }
 
+  function formatVersionDate (value) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? "" : date.toISOString().slice(0, 10);
+  }
+
+  async function updateVersionFooter (versionConfig = {}) {
+    const versionEl = $("appVersion");
+    if (!versionEl) return;
+
+    const {
+      githubRepository,
+      branch = "main",
+      fallbackDate = ""
+    } = versionConfig;
+
+    if (fallbackDate) versionEl.textContent = fallbackDate;
+    if (!githubRepository) return;
+
+    const [owner, repo] = githubRepository.split("/");
+    if (!owner || !repo) return;
+
+    try {
+      const response = await fetch(
+        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${encodeURIComponent(branch)}`,
+        { cache: "no-store" }
+      );
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+      const commitData = await response.json();
+      const versionDate = formatVersionDate(commitData?.commit?.committer?.date);
+      if (versionDate) versionEl.textContent = versionDate;
+    } catch (err) {
+      console.warn("Nie udało się pobrać daty wersji z GitHub API.", err);
+    }
+  }
+
   function clearFieldWarnings () {
     document.querySelectorAll(".field-warning").forEach(el => el.remove());
     document.querySelectorAll(".input-warning").forEach(el => el.classList.remove("input-warning"));
@@ -126,6 +162,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     showAppMessage("error", "Błąd konfiguracji", "Nie udało się wczytać pliku config.json.");
     return;
   }
+
+  void updateVersionFooter(cfg.versionConfig);
 
   /* Rozpakowanie */
   const {

--- a/style.css
+++ b/style.css
@@ -9,6 +9,8 @@ body{
   font-family:Arial, sans-serif;
   background-color:#f0f4f8;
   display:flex;
+  flex-direction:column;
+  align-items:center;
   justify-content:center;
   padding:2rem;
 }
@@ -358,3 +360,11 @@ button:hover{background-color:#005fa3;}
   border-radius:4px;
   padding:0.75rem;
 }
+.app-footer{
+  margin-top:1.25rem;
+  color:#777;
+  font-size:0.85rem;
+  line-height:1.4;
+  text-align:center;
+}
+

--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -336,6 +336,18 @@ test('safety note is shown in the right parameters panel', () => {
   assert.ok(safetyNoteIndex > patientPanelIndex);
 });
 
+
+test('application footer shows author and loads main branch version date automatically', () => {
+  assert.match(indexHtml, /<footer class="app-footer"[^>]*>/);
+  assert.match(indexHtml, /Autor: Maciej Piekarski/);
+  assert.match(indexHtml, /Wersja: <span id="appVersion">ładowanie\.\.\.<\/span>/);
+  assert.equal(cfg.versionConfig.githubRepository, 'macpiek/parenteral_nutrition_generator');
+  assert.equal(cfg.versionConfig.branch, 'main');
+  assert.match(scriptJs, /api\.github\.com\/repos/);
+  assert.match(scriptJs, /commits\/\$\{encodeURIComponent\(branch\)\}/);
+  assert.match(scriptJs, /commitData\?\.commit\?\.committer\?\.date/);
+});
+
 test('mixture parameters table includes extended composition rows', () => {
   [
     'caTotal',


### PR DESCRIPTION
### Motivation
- Provide a visible app attribution and a reproducible version/date indicator in the UI to help identify deployments.
- Allow the UI to show a human-readable version date derived from the repository commit, with a configurable fallback.

### Description
- Added `versionConfig` to `config.json` with `githubRepository`, `branch`, and `fallbackDate` fields to drive version display.
- Appended a footer to `index.html` showing the author and a `span` with id `appVersion` for the version date.
- Implemented `updateVersionFooter` in `script.js` to fetch the latest commit for the configured repo/branch from the GitHub API, format the commit date, and populate `#appVersion`, falling back to `fallbackDate` on error; wired the call to `updateVersionFooter(cfg.versionConfig)` after config load.
- Minor layout and styling adjustments in `style.css` to support footer layout and vertical centering.
- Extended tests in `test/pnCalculator.test.js` to assert the presence of the footer, author text, initial loading placeholder, and that `versionConfig` and GitHub API usage are present in the code.

### Testing
- Ran the unit test suite under `test/` (via `npm test`); all tests including the new footer/version assertions passed.
- Verified added tests check `index.html`, `script.js`, and `config.json` for the expected `app-footer`, `appVersion` placeholder and `versionConfig` values, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a256b9bddac832e961298c863b2f87e)