### PR TITLE
Bump script.js cache-busting query string

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <script src="vendor/file-saver/FileSaver.min.js"></script>
 
   <script src="pnCalculator.js?v=20260606-2" defer></script>
-  <script src="script.js?v=20260606-2" defer></script>
+  <script src="script.js?v=20260607-1" defer></script>
   <script src="xlsxGenerator.js?v=20260606-2" defer></script>
 
   <!-- Główny arkusz stylów -->

--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -350,6 +350,7 @@ test('application footer shows author and loads main branch version date automat
   assert.match(indexHtml, /<footer class="app-footer"[^>]*>/);
   assert.match(indexHtml, /Autor: Maciej Piekarski/);
   assert.match(indexHtml, /Wersja: <span id="appVersion">ładowanie\.\.\.<\/span>/);
+  assert.match(indexHtml, /<script src="script\.js\?v=20260607-1" defer><\/script>/);
   assert.equal(cfg.versionConfig.githubRepository, 'macpiek/parenteral_nutrition_generator');
   assert.equal(cfg.versionConfig.branch, 'main');
   assert.match(scriptJs, /api\.github\.com\/repos/);


### PR DESCRIPTION
### Motivation
- The UI behavior changed in `script.js` but the `index.html` script URL still used the old query string, which would allow cached clients to keep loading the pre-change asset and show stale UI text (`ładowanie...`), so the asset cache key must be bumped.

### Description
- Updated the `script.js` include in `index.html` to `script.js?v=20260607-1` and added a test assertion in `test/pnCalculator.test.js` to verify the new cache-busting URL is present.

### Testing
- Ran `npm test` and `npm run check:syntax`, and both test/syntax checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2575ca644c832eb761bd51ac79c6aa)