### PR TITLE
Anchor footer to bottom and hardcode version date; add update script

### DIFF
--- a/config.json
+++ b/config.json
@@ -159,8 +159,7 @@
     },
 
     "versionConfig": {
-      "githubRepository": "macpiek/parenteral_nutrition_generator",
-      "branch": "main",
+      "date": "2026-06-07",
       "fallbackDate": "2026-06-07"
     },
 

--- a/config.json
+++ b/config.json
@@ -159,8 +159,9 @@
     },
 
     "versionConfig": {
+      "updatedAt": "2026-06-07 13:54",
       "date": "2026-06-07",
-      "fallbackDate": "2026-06-07"
+      "fallbackDate": "2026-06-07 13:54"
     },
 
     "constants": {

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
   <!-- FileSaver do pobierania pliku -->
   <script src="vendor/file-saver/FileSaver.min.js"></script>
 
-  <script src="pnCalculator.js?v=20260607" defer></script>
-  <script src="script.js?v=20260607" defer></script>
-  <script src="xlsxGenerator.js?v=20260607" defer></script>
+  <script src="pnCalculator.js?v=202606071354" defer></script>
+  <script src="script.js?v=202606071354" defer></script>
+  <script src="xlsxGenerator.js?v=202606071354" defer></script>
 
   <!-- Główny arkusz stylów -->
   <link rel="stylesheet" href="style.css">
@@ -286,7 +286,7 @@
   </div><!-- /wrapper -->
   <footer class="app-footer" aria-label="Informacje o aplikacji">
     <div>Autor: Maciej Piekarski</div>
-    <div>Wersja: <span id="appVersion" data-version-date="2026-06-07">2026-06-07</span></div>
+    <div>Wersja: <span id="appVersion" data-version-updated-at="2026-06-07 13:54">2026-06-07 13:54</span></div>
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
   <!-- FileSaver do pobierania pliku -->
   <script src="vendor/file-saver/FileSaver.min.js"></script>
 
-  <script src="pnCalculator.js?v=20260606-2" defer></script>
-  <script src="script.js?v=20260606-2" defer></script>
-  <script src="xlsxGenerator.js?v=20260606-2" defer></script>
+  <script src="pnCalculator.js?v=20260607" defer></script>
+  <script src="script.js?v=20260607" defer></script>
+  <script src="xlsxGenerator.js?v=20260607" defer></script>
 
   <!-- Główny arkusz stylów -->
   <link rel="stylesheet" href="style.css">
@@ -286,7 +286,7 @@
   </div><!-- /wrapper -->
   <footer class="app-footer" aria-label="Informacje o aplikacji">
     <div>Autor: Maciej Piekarski</div>
-    <div>Wersja: <span id="appVersion">ładowanie...</span></div>
+    <div>Wersja: <span id="appVersion" data-version-date="2026-06-07">2026-06-07</span></div>
   </footer>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "description": "Generator recepty żywienia parenteralnego z walidacją danych i testami jednostkowymi.",
   "scripts": {
+    "update:version-date": "node scripts/update-version-date.mjs",
+    "pretest": "node scripts/update-version-date.mjs",
+    "precheck:syntax": "node scripts/update-version-date.mjs",
     "test": "node --test",
-    "check:syntax": "node --check script.js && node --check xlsxGenerator.js && node --check pnCalculator.js"
+    "check:syntax": "node --check script.js && node --check xlsxGenerator.js && node --check pnCalculator.js && node --check scripts/update-version-date.mjs"
   },
   "dependencies": {
     "exceljs": "^4.4.0",

--- a/script.js
+++ b/script.js
@@ -58,12 +58,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     const versionEl = $("appVersion");
     if (!versionEl) return;
 
-    const hardcodedDate = versionConfig.date
+    const hardcodedTimestamp = versionConfig.updatedAt
       || versionConfig.fallbackDate
+      || versionEl.dataset.versionUpdatedAt
       || versionEl.dataset.versionDate
+      || versionConfig.date
       || versionEl.textContent.trim();
 
-    versionEl.textContent = hardcodedDate || "brak daty";
+    versionEl.textContent = hardcodedTimestamp || "brak daty";
   }
 
   function clearFieldWarnings () {

--- a/script.js
+++ b/script.js
@@ -54,40 +54,16 @@ document.addEventListener("DOMContentLoaded", async () => {
     generationMessage.textContent = "";
   }
 
-  function formatVersionDate (value) {
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? "" : date.toISOString().slice(0, 10);
-  }
-
-  async function updateVersionFooter (versionConfig = {}) {
+  function updateVersionFooter (versionConfig = {}) {
     const versionEl = $("appVersion");
     if (!versionEl) return;
 
-    const {
-      githubRepository,
-      branch = "main",
-      fallbackDate = ""
-    } = versionConfig;
+    const hardcodedDate = versionConfig.date
+      || versionConfig.fallbackDate
+      || versionEl.dataset.versionDate
+      || versionEl.textContent.trim();
 
-    if (fallbackDate) versionEl.textContent = fallbackDate;
-    if (!githubRepository) return;
-
-    const [owner, repo] = githubRepository.split("/");
-    if (!owner || !repo) return;
-
-    try {
-      const response = await fetch(
-        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${encodeURIComponent(branch)}`,
-        { cache: "no-store" }
-      );
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-
-      const commitData = await response.json();
-      const versionDate = formatVersionDate(commitData?.commit?.committer?.date);
-      if (versionDate) versionEl.textContent = versionDate;
-    } catch (err) {
-      console.warn("Nie udało się pobrać daty wersji z GitHub API.", err);
-    }
+    versionEl.textContent = hardcodedDate || "brak daty";
   }
 
   function clearFieldWarnings () {
@@ -163,7 +139,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  void updateVersionFooter(cfg.versionConfig);
+  updateVersionFooter(cfg.versionConfig);
 
   /* Rozpakowanie */
   const {

--- a/scripts/update-version-date.mjs
+++ b/scripts/update-version-date.mjs
@@ -1,7 +1,18 @@
 import { readFile, writeFile } from "node:fs/promises";
 
-const VERSION_DATE = new Date().toISOString().slice(0, 10);
-const CACHE_BUSTER = VERSION_DATE.replaceAll("-", "");
+const now = new Date();
+const pad = value => String(value).padStart(2, "0");
+const VERSION_DATE = [
+  now.getFullYear(),
+  pad(now.getMonth() + 1),
+  pad(now.getDate())
+].join("-");
+const VERSION_TIME = [
+  pad(now.getHours()),
+  pad(now.getMinutes())
+].join(":");
+const VERSION_TIMESTAMP = `${VERSION_DATE} ${VERSION_TIME}`;
+const CACHE_BUSTER = `${VERSION_DATE.replaceAll("-", "")}${VERSION_TIME.replace(":", "")}`;
 
 async function updateTextFile (path, updater) {
   const raw = await readFile(path, "utf8");
@@ -13,14 +24,14 @@ async function updateTextFile (path, updater) {
 
 await updateTextFile("config.json", json => json.replace(
   /    "versionConfig": \{[\s\S]*?    \},\n\n    "constants":/,
-  `    "versionConfig": {\n      "date": "${VERSION_DATE}",\n      "fallbackDate": "${VERSION_DATE}"\n    },\n\n    "constants":`
+  `    "versionConfig": {\n      "updatedAt": "${VERSION_TIMESTAMP}",\n      "date": "${VERSION_DATE}",\n      "fallbackDate": "${VERSION_TIMESTAMP}"\n    },\n\n    "constants":`
 ));
 
 await updateTextFile("index.html", html => html
   .replace(/(src="pnCalculator\.js\?v=)[^"]+"/, `$1${CACHE_BUSTER}"`)
   .replace(/(src="script\.js\?v=)[^"]+"/, `$1${CACHE_BUSTER}"`)
   .replace(/(src="xlsxGenerator\.js\?v=)[^"]+"/, `$1${CACHE_BUSTER}"`)
-  .replace(/<span id="appVersion"(?: data-version-date="[^"]*")?>[^<]*<\/span>/,
-    `<span id="appVersion" data-version-date="${VERSION_DATE}">${VERSION_DATE}</span>`));
+  .replace(/<span id="appVersion"(?: data-version-updated-at="[^"]*")?(?: data-version-date="[^"]*")?>[^<]*<\/span>/,
+    `<span id="appVersion" data-version-updated-at="${VERSION_TIMESTAMP}">${VERSION_TIMESTAMP}</span>`));
 
-console.log(`Ustawiono datę wersji aplikacji: ${VERSION_DATE}`);
+console.log(`Ustawiono datę i godzinę wersji aplikacji: ${VERSION_TIMESTAMP}`);

--- a/scripts/update-version-date.mjs
+++ b/scripts/update-version-date.mjs
@@ -1,0 +1,26 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const VERSION_DATE = new Date().toISOString().slice(0, 10);
+const CACHE_BUSTER = VERSION_DATE.replaceAll("-", "");
+
+async function updateTextFile (path, updater) {
+  const raw = await readFile(path, "utf8");
+  const updated = updater(raw);
+  if (updated !== raw) {
+    await writeFile(path, updated, "utf8");
+  }
+}
+
+await updateTextFile("config.json", json => json.replace(
+  /    "versionConfig": \{[\s\S]*?    \},\n\n    "constants":/,
+  `    "versionConfig": {\n      "date": "${VERSION_DATE}",\n      "fallbackDate": "${VERSION_DATE}"\n    },\n\n    "constants":`
+));
+
+await updateTextFile("index.html", html => html
+  .replace(/(src="pnCalculator\.js\?v=)[^"]+"/, `$1${CACHE_BUSTER}"`)
+  .replace(/(src="script\.js\?v=)[^"]+"/, `$1${CACHE_BUSTER}"`)
+  .replace(/(src="xlsxGenerator\.js\?v=)[^"]+"/, `$1${CACHE_BUSTER}"`)
+  .replace(/<span id="appVersion"(?: data-version-date="[^"]*")?>[^<]*<\/span>/,
+    `<span id="appVersion" data-version-date="${VERSION_DATE}">${VERSION_DATE}</span>`));
+
+console.log(`Ustawiono datę wersji aplikacji: ${VERSION_DATE}`);

--- a/style.css
+++ b/style.css
@@ -6,12 +6,13 @@
 }
 
 body{
+  min-height:100vh;
   font-family:Arial, sans-serif;
   background-color:#f0f4f8;
   display:flex;
   flex-direction:column;
   align-items:center;
-  justify-content:center;
+  justify-content:flex-start;
   padding:2rem;
 }
 
@@ -365,7 +366,8 @@ button:hover{background-color:#005fa3;}
   padding:0.75rem;
 }
 .app-footer{
-  margin-top:1.25rem;
+  margin-top:auto;
+  padding-top:1.25rem;
   color:#777;
   font-size:0.85rem;
   line-height:1.4;

--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -346,14 +346,15 @@ test('safety note is shown in the right parameters panel', () => {
 });
 
 
-test('application footer shows author and hardcoded version date', () => {
+test('application footer shows author and hardcoded version date and time', () => {
   assert.match(indexHtml, /<footer class="app-footer"[^>]*>/);
   assert.match(indexHtml, /Autor: Maciej Piekarski/);
-  assert.match(indexHtml, /Wersja: <span id="appVersion" data-version-date="\d{4}-\d{2}-\d{2}">\d{4}-\d{2}-\d{2}<\/span>/);
+  assert.match(indexHtml, /Wersja: <span id="appVersion" data-version-updated-at="\d{4}-\d{2}-\d{2} \d{2}:\d{2}">\d{4}-\d{2}-\d{2} \d{2}:\d{2}<\/span>/);
+  assert.match(cfg.versionConfig.updatedAt, /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
   assert.match(cfg.versionConfig.date, /^\d{4}-\d{2}-\d{2}$/);
-  assert.equal(cfg.versionConfig.fallbackDate, cfg.versionConfig.date);
+  assert.equal(cfg.versionConfig.fallbackDate, cfg.versionConfig.updatedAt);
   assert.doesNotMatch(scriptJs, /api\.github\.com\/repos/);
-  assert.match(scriptJs, /versionConfig\.date/);
+  assert.match(scriptJs, /versionConfig\.updatedAt/);
 });
 
 test('mixture parameters table includes extended composition rows', () => {

--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -346,15 +346,14 @@ test('safety note is shown in the right parameters panel', () => {
 });
 
 
-test('application footer shows author and loads main branch version date automatically', () => {
+test('application footer shows author and hardcoded version date', () => {
   assert.match(indexHtml, /<footer class="app-footer"[^>]*>/);
   assert.match(indexHtml, /Autor: Maciej Piekarski/);
-  assert.match(indexHtml, /Wersja: <span id="appVersion">ładowanie\.\.\.<\/span>/);
-  assert.equal(cfg.versionConfig.githubRepository, 'macpiek/parenteral_nutrition_generator');
-  assert.equal(cfg.versionConfig.branch, 'main');
-  assert.match(scriptJs, /api\.github\.com\/repos/);
-  assert.match(scriptJs, /commits\/\$\{encodeURIComponent\(branch\)\}/);
-  assert.match(scriptJs, /commitData\?\.commit\?\.committer\?\.date/);
+  assert.match(indexHtml, /Wersja: <span id="appVersion" data-version-date="\d{4}-\d{2}-\d{2}">\d{4}-\d{2}-\d{2}<\/span>/);
+  assert.match(cfg.versionConfig.date, /^\d{4}-\d{2}-\d{2}$/);
+  assert.equal(cfg.versionConfig.fallbackDate, cfg.versionConfig.date);
+  assert.doesNotMatch(scriptJs, /api\.github\.com\/repos/);
+  assert.match(scriptJs, /versionConfig\.date/);
 });
 
 test('mixture parameters table includes extended composition rows', () => {


### PR DESCRIPTION
### Motivation
- The footer did not stick to the bottom on short viewports and version info relied on a failing runtime GitHub API fetch, so make the footer reliably positioned and show a version date immediately. 
- Provide a deterministic, automated way to stamp the project with the current date when files are modified to avoid flaky network-dependent behavior.

### Description
- Adjusted layout/CSS so the page uses column flow from the top, `body` has `min-height:100vh` and the footer uses `margin-top:auto` so it stays at the bottom on short pages (`style.css`).
- Removed runtime GitHub API lookup and replaced it with a simple hardcoded/element-provided date path: the footer now shows a date from `config.json`/element dataset and `script.js` no longer calls GitHub (it uses `versionConfig.date`/`fallbackDate`/`data-version-date`).
- Added `scripts/update-version-date.mjs` which inserts the current UTC date into `config.json`, updates the footer `data-version-date`, and updates the `?v=` cache busters in `index.html` for JS files.
- Wired the automation into project scripts by adding `update:version-date` and running it as `pretest`/`precheck:syntax` in `package.json`, and updated the footer/date in `index.html` and `config.json` accordingly.
- Updated unit tests in `test/pnCalculator.test.js` to expect a hardcoded version date and removed assertions that required the GitHub API behaviour.

### Testing
- Ran `npm test` (which executes the `pretest` update script first); all tests passed (31/31).
- Ran `npm run check:syntax` (including `node --check` on JS files and the update script); syntax checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257617f728832e99c66ff4da833429)