### PR TITLE
Pokaż łączną objętość mieszaniny w panelu parametrów

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <script src="vendor/file-saver/FileSaver.min.js"></script>
 
   <script src="pnCalculator.js?v=20260606-2" defer></script>
-  <script src="script.js?v=20260607-1" defer></script>
+  <script src="script.js?v=20260607-2" defer></script>
   <script src="xlsxGenerator.js?v=20260606-2" defer></script>
 
   <!-- Główny arkusz stylów -->
@@ -221,6 +221,12 @@
             <td><span id="bagCalories"></span> kcal</td>
             <td>&ndash;</td>
             <td><span id="calReqMin">0</span> - <span id="calReqMax">0</span> kcal</td>
+          </tr>
+          <tr>
+            <td>Objętość (łącznie)</td>
+            <td><span id="totalMixtureVolume"></span> ml</td>
+            <td>&ndash;</td>
+            <td>&ndash;</td>
           </tr>
           <tr>
             <td>Sód</td>

--- a/pnCalculator.js
+++ b/pnCalculator.js
@@ -94,6 +94,18 @@
     return total ? Math.round(total) : 0;
   }
 
+  function calculateTotalVolume ({ bagConfig, bag, volume, additives = {}, additiveConfig }) {
+    const info = getBagInfo(bagConfig, bag, volume);
+    let total = info ? Number(info.vol) : (parseNumber(volume) || 0);
+
+    for (const [id, additive] of Object.entries(additiveConfig || {})) {
+      if (additive.unit !== "ml") continue;
+      total += parseNumber(additives[id]) || 0;
+    }
+
+    return total ? Math.round(total * 10) / 10 : 0;
+  }
+
   function calculateAdditiveRanges ({ additiveRangeConfig, constants, bag, volume, weight }) {
     const cfgRange = additiveRangeConfig[bag]?.[Number(volume)];
     const numericWeight = parseNumber(weight) || 0;
@@ -266,6 +278,7 @@
     getAdditiveEnergyConfig,
     getAdditiveElectrolyteConfig,
     calculateTotalKcal,
+    calculateTotalVolume,
     calculateMixtureSummary,
     calculateAdditiveRanges,
     calculateElectrolyteSummary,

--- a/script.js
+++ b/script.js
@@ -190,6 +190,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const {
     parseNumber: parseNum,
     calculateTotalKcal,
+    calculateTotalVolume,
     calculateAdditiveRanges,
     calculateElectrolyteSummary,
     calculateMixtureSummary,
@@ -198,7 +199,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   } = PNCalculator;
 
   const kcalSpan = $("bagCalories");
-  const additiveEnergyIds = Object.keys(PNCalculator.getAdditiveEnergyConfig(cfg.additiveConfig));
+  const totalVolumeSpan = $("totalMixtureVolume");
   const additiveCompositionIds = Object.entries(cfg.additiveConfig || {})
     .filter(([, additive]) => additive.compositionPerMl)
     .map(([id]) => id);
@@ -234,21 +235,31 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const additiveInputIds = Array.from({ length: 17 }, (_, i) => `add${i + 1}`);
 
+  const readAdditiveValues = () => Object.fromEntries(
+    additiveInputIds.map(id => [id, $(id)?.value || ""])
+  );
+
   const updateKcal = () => {
-    const additives = Object.fromEntries(additiveEnergyIds.map(id => [id, $(id)?.value]));
     const total = calculateTotalKcal({
       bagConfig,
       bag: currentBag(),
       volume: volSel.value,
-      additives,
+      additives: readAdditiveValues(),
       additiveConfig: cfg.additiveConfig
     });
     kcalSpan.textContent = total || "";
   };
 
-  const readAdditiveValues = () => Object.fromEntries(
-    additiveInputIds.map(id => [id, $(id)?.value || ""])
-  );
+  const updateTotalVolume = () => {
+    const total = calculateTotalVolume({
+      bagConfig,
+      bag: currentBag(),
+      volume: volSel.value,
+      additives: readAdditiveValues(),
+      additiveConfig: cfg.additiveConfig
+    });
+    totalVolumeSpan.textContent = total || "";
+  };
 
   function collectValidationData () {
     return {
@@ -297,6 +308,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   ["add6", "add8"].forEach(id => {
     const el = $(id);
     if (el) el.addEventListener("input", updateKcal);
+  });
+
+  additiveInputIds.forEach(id => {
+    const el = $(id);
+    if (el) el.addEventListener("input", updateTotalVolume);
   });
 
   /* ---------- 3. Inicjalizacja dat ---------- */
@@ -520,6 +536,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     aminoAcidsTotal.textContent = mixtureSummary.aminoAcids;
     carbohydratesTotal.textContent = mixtureSummary.carbohydrates;
     fatTotal.textContent = mixtureSummary.fat;
+    updateTotalVolume();
   }
 
   /* --- worki & kcal --- */
@@ -537,6 +554,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
 
     updateKcal();
+    updateTotalVolume();
     updateDosage();
     updateAdditiveRanges();
     if (!preserveDefaults) applyDefaultAdditives();
@@ -572,6 +590,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
   volSel    .addEventListener("change", () => {
     updateKcal();
+    updateTotalVolume();
     updateDosage();
     updateAdditiveRanges();
     updateElectrolyteSummary();

--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -32,6 +32,25 @@ test('calculateTotalKcal includes bag calories plus Dipeptiven and Omegaven calo
   }), 868);
 });
 
+test('calculateTotalVolume includes selected bag volume and ml additives', () => {
+  assert.equal(calc.calculateTotalVolume({
+    bagConfig: cfg.bagConfig,
+    bag: 'SmofKabiven Peripheral',
+    volume: 1206,
+    additiveConfig: cfg.additiveConfig,
+    additives: {
+      add1: '10,5',
+      add2: '10',
+      add3: '1',
+      add4: '10',
+      add6: '50',
+      add8: '25',
+      add10: '10',
+      add17: '10'
+    }
+  }), 1331.5);
+});
+
 test('calculateAdditiveRanges limits Dipeptiven and Omegaven by both bag and patient weight', () => {
   const ranges = calc.calculateAdditiveRanges({
     additiveRangeConfig: cfg.additiveRangeConfig,
@@ -350,7 +369,7 @@ test('application footer shows author and loads main branch version date automat
   assert.match(indexHtml, /<footer class="app-footer"[^>]*>/);
   assert.match(indexHtml, /Autor: Maciej Piekarski/);
   assert.match(indexHtml, /Wersja: <span id="appVersion">ładowanie\.\.\.<\/span>/);
-  assert.match(indexHtml, /<script src="script\.js\?v=20260607-1" defer><\/script>/);
+  assert.match(indexHtml, /<script src="script\.js\?v=20260607-2" defer><\/script>/);
   assert.equal(cfg.versionConfig.githubRepository, 'macpiek/parenteral_nutrition_generator');
   assert.equal(cfg.versionConfig.branch, 'main');
   assert.match(scriptJs, /api\.github\.com\/repos/);
@@ -358,8 +377,9 @@ test('application footer shows author and loads main branch version date automat
   assert.match(scriptJs, /commitData\?\.commit\?\.committer\?\.date/);
 });
 
-test('mixture parameters table includes extended composition rows', () => {
+test('mixture parameters table includes extended composition rows and total volume', () => {
   [
+    'totalMixtureVolume',
     'caTotal',
     'phosphateTotal',
     'mgTotal',


### PR DESCRIPTION
### Motivation
- Umożliwić wyświetlenie łącznej objętości przygotowanej mieszaniny (objętość worka + dodatki w ml) w sekcji „Parametry mieszaniny”.

### Description
- Dodano wiersz „Objętość (łącznie)” do tabeli parametrów w `index.html` z polem `id="totalMixtureVolume"` dla wyświetlania wartości. 
- Dodano funkcję `calculateTotalVolume` do `pnCalculator.js`, która sumuje objętość wybranego worka (`bagConfig`) oraz wszystkie dodatki z `additiveConfig` mające `unit: "ml"`. 
- Zintegrowano obliczenia w UI w `script.js` przez dodanie `readAdditiveValues`, `updateTotalVolume`, rejestrację nasłuchiwaczy input/change i wywoływanie odświeżania przy zmianie worka, dodatków i przy renderowaniu opcji worka, oraz zaktualizowano wersję `script.js` w `index.html`. 
- Dodano test jednostkowy `calculateTotalVolume` i zaktualizowano testy sprawdzające obecność pola w HTML oraz odświeżenie querystringu skryptu w `test/pnCalculator.test.js`.

### Testing
- Uruchomiono składniowe sprawdzenie plików za pomocą `npm run check:syntax`, które zakończyło się pomyślnie. 
- Uruchomiono testy jednostkowe `npm test` i wszystkie testy przeszły pomyślnie (`32` testy, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257ae2192c832eae9543d7c361323f)