### PR TITLE
Resetowanie wartości formularza po odświeżeniu

### DIFF
--- a/script.js
+++ b/script.js
@@ -54,6 +54,30 @@ document.addEventListener("DOMContentLoaded", async () => {
     generationMessage.textContent = "";
   }
 
+  function resetControlToInitialValue (el) {
+    if (el.tagName === "SELECT") {
+      const defaultIndex = Array.from(el.options).findIndex(option => option.defaultSelected);
+      el.selectedIndex = defaultIndex >= 0 ? defaultIndex : (el.options.length ? 0 : -1);
+      return;
+    }
+
+    if (el.type === "checkbox" || el.type === "radio") {
+      el.checked = el.defaultChecked;
+      return;
+    }
+
+    el.value = el.defaultValue || "";
+  }
+
+  function resetBrowserRestoredValues () {
+    document.querySelectorAll("input, select, textarea").forEach(el => {
+      el.setAttribute("autocomplete", "off");
+      resetControlToInitialValue(el);
+    });
+  }
+
+  resetBrowserRestoredValues();
+
   function formatVersionDate (value) {
     const date = new Date(value);
     return Number.isNaN(date.getTime()) ? "" : date.toISOString().slice(0, 10);


### PR DESCRIPTION
### Motivation
- Zapobiec przywracaniu przez przeglądarkę wcześniej wpisanych wartości w polach formularza po odświeżeniu strony, tak by widoczne wartości zawsze odpowiadały domyślnym ustawieniom aplikacji.

### Description
- Dodano funkcję `resetControlToInitialValue` oraz `resetBrowserRestoredValues` w `script.js`, która przy starcie ustawia wszystkie `input`, `select` i `textarea` do ich wartości domyślnych.
- W trakcie inicjalizacji aplikacji ustawiane jest `autocomplete="off"` dla kontrolek, aby zapobiec automatycznemu przywracaniu wpisanych wcześniej danych przez przeglądarkę.

### Testing
- Uruchomiono `npm run check:syntax` oraz `npm test`, oba polecenia przeszły pomyślnie (wszystkie testy przeszły: 32 pass, 0 fail).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a258095d90c832e971515fe0d8e1a56)