### PR TITLE
Focus patient name field on startup

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 
         <div class="form-group">
           <label for="fullname">Imię i nazwisko</label>
-          <input type="text" id="fullname">
+          <input type="text" id="fullname" autofocus>
         </div>
 
         <div class="form-group">

--- a/script.js
+++ b/script.js
@@ -78,6 +78,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   resetBrowserRestoredValues();
 
+  const fullnameInp = $("fullname");
+  if (fullnameInp) fullnameInp.focus();
+
   function formatVersionDate (value) {
     const date = new Date(value);
     return Number.isNaN(date.getTime()) ? "" : date.toISOString().slice(0, 10);

--- a/test/pnCalculator.test.js
+++ b/test/pnCalculator.test.js
@@ -315,6 +315,11 @@ test('application starts with default patient weight of 65 kg', () => {
   assert.match(scriptJs, /weightInp\.value\s*=\s*"65"/);
 });
 
+test('application focuses the patient full name field on startup', () => {
+  assert.match(indexHtml, /<input type="text" id="fullname" autofocus>/);
+  assert.match(scriptJs, /const fullnameInp = \$\("fullname"\);[\s\S]*fullnameInp\.focus\(\)/);
+});
+
 test('form uses the application validation panel instead of native browser bubbles', () => {
   assert.match(indexHtml, /<form[^>]*id="daneForm"[^>]*novalidate/);
 });


### PR DESCRIPTION
### Motivation
- Ułatwić wprowadzanie danych pacjenta poprzez automatyczne ustawienie fokusu w polu „Imię i nazwisko” po uruchomieniu aplikacji.

### Description
- Dodano atrybut `autofocus` do pola `#fullname` w `index.html` i wywołanie `focus()` na tym elemencie w `DOMContentLoaded` po `resetBrowserRestoredValues()` w `script.js` (pliki: `index.html`, `script.js`).
- Dodano test regresji sprawdzający obecność `autofocus` w HTML oraz wywołanie `focus()` w skrypcie (`test/pnCalculator.test.js`).

### Testing
- Uruchomiono `npm test`, wszystkie testy przeszły (33 passed). 
- Uruchomiono `npm run check:syntax`, sprawdzenie składni zakończone pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a258f0987f8832eaa060ffbc8fcb6d1)